### PR TITLE
feat(audit): deliver the Company Portal Audit Trail

### DIFF
--- a/src/app/routes/company/audit/index.tsx
+++ b/src/app/routes/company/audit/index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { CompanyAuditPage } from "@/pages/company/audit";
+
+// The Company route scopes itself to the authenticated identity, so paging is the whole
+// search contract — a Company or scope filter has nowhere to be expressed.
+const companyAuditSearchSchema = z.object({
+  cursor: z.string().max(500).optional().catch(undefined),
+  limit: z.coerce.number().int().min(1).max(100).catch(50),
+});
+
+export const Route = createFileRoute("/company/audit/")({
+  validateSearch: companyAuditSearchSchema.parse,
+  component: CompanyAuditPage,
+});

--- a/src/pages/company/audit/api/audit-runtime-contract.test.ts
+++ b/src/pages/company/audit/api/audit-runtime-contract.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { parseCompanyAuditTrailPage } from "./audit-runtime-contract";
+
+const profileUpdatedEvent = {
+  eventType: "company.profile.material_updated",
+  eventVersion: 1,
+  occurredAt: "2026-08-13T10:00:00.000Z",
+  outcome: "SUCCESS",
+  actor: { kind: "USER", publicId: "550e8400-e29b-41d4-a716-446655440000" },
+  traceId: "5fc21e3361b0fe234353b1176c5b2fdf",
+  targets: [{ targetType: "company-profile", publicId: "profile-1" }],
+  details: {
+    changes: [{ field: "name", before: "Northwind", after: "Northwind Egypt" }],
+  },
+};
+
+describe("parseCompanyAuditTrailPage", () => {
+  it("returns the page for a Company Projection event", () => {
+    const parsed = parseCompanyAuditTrailPage({
+      items: [profileUpdatedEvent],
+      nextCursor: "opaque-cursor-token",
+      hasMore: true,
+    });
+
+    expect(parsed.items[0]?.eventType).toBe("company.profile.material_updated");
+    expect(parsed.nextCursor).toBe("opaque-cursor-token");
+    expect(parsed.hasMore).toBe(true);
+  });
+
+  it("returns the page for a profile completion event", () => {
+    const parsed = parseCompanyAuditTrailPage({
+      items: [
+        {
+          ...profileUpdatedEvent,
+          eventType: "company.profile.completed",
+          details: { beforeStatus: "INCOMPLETE", afterStatus: "COMPLETE" },
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    expect(parsed.items[0]?.eventType).toBe("company.profile.completed");
+  });
+
+  it("returns the page for history the reader can no longer project", () => {
+    const parsed = parseCompanyAuditTrailPage({
+      items: [
+        {
+          eventType: "audit.event.unavailable",
+          eventVersion: 1,
+          occurredAt: "2026-08-13T10:01:00.000Z",
+          reason: "UNSUPPORTED_OR_DAMAGED",
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    expect(parsed.items[0]?.eventType).toBe("audit.event.unavailable");
+  });
+
+  it("rejects an item whose eventType is outside the generated union", () => {
+    expect(() =>
+      parseCompanyAuditTrailPage({
+        items: [{ ...profileUpdatedEvent, eventType: "company.profile.invented" }],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    ).toThrow();
+  });
+
+  it("accepts a Platform Admin actor reported without an identity", () => {
+    const parsed = parseCompanyAuditTrailPage({
+      items: [{ ...profileUpdatedEvent, actor: { kind: "PLATFORM_ADMIN" } }],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    expect(parsed.items[0]?.eventType).toBe("company.profile.material_updated");
+  });
+
+  it.each([
+    "scope",
+    "companyPublicId",
+    "origin",
+  ])("rejects an event carrying the Platform-only %s field", (platformOnlyField) => {
+    expect(() =>
+      parseCompanyAuditTrailPage({
+        items: [{ ...profileUpdatedEvent, [platformOnlyField]: "PLATFORM" }],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an event stored under an unsupported version", () => {
+    expect(() =>
+      parseCompanyAuditTrailPage({
+        items: [{ ...profileUpdatedEvent, eventVersion: 2 }],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a page missing the hasMore indicator", () => {
+    expect(() =>
+      parseCompanyAuditTrailPage({ items: [profileUpdatedEvent], nextCursor: null }),
+    ).toThrow();
+  });
+
+  it("rejects a Platform Admin actor carrying a public identifier", () => {
+    expect(() =>
+      parseCompanyAuditTrailPage({
+        items: [
+          {
+            ...profileUpdatedEvent,
+            actor: {
+              kind: "PLATFORM_ADMIN",
+              publicId: "550e8400-e29b-41d4-a716-446655440000",
+            },
+          },
+        ],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    ).toThrow();
+  });
+});

--- a/src/pages/company/audit/api/audit-runtime-contract.ts
+++ b/src/pages/company/audit/api/audit-runtime-contract.ts
@@ -1,0 +1,104 @@
+/**
+ * Runtime half of the Company Audit Trail contract: it re-states the generated
+ * `CompanyAuditTrailPage` as Zod so responses stay checked after TypeScript types are erased.
+ * The return type of `parseCompanyAuditTrailPage` ties the two together — if the schemas drift
+ * apart, the compiler fails before any test does.
+ */
+
+import { z } from "zod";
+import type { components } from "@/shared/api";
+
+export type CompanyAuditTrailPage = components["schemas"]["CompanyAuditTrailPage"];
+
+// A Company reader learns that Edara acted, never which Platform Admin acted, so the
+// PLATFORM_ADMIN member carries no identifier and `.strict()` rejects one that appears.
+const actorSchema = z.union([
+  z.object({ kind: z.literal("USER"), publicId: z.string().uuid() }).strict(),
+  z.object({ kind: z.literal("PLATFORM_ADMIN") }).strict(),
+  z
+    .object({
+      kind: z.literal("SYSTEM"),
+      component: z.enum(["EMAIL_WORKER", "SCHEDULER", "SCRIPT"]),
+    })
+    .strict(),
+  z.object({ kind: z.literal("ANONYMOUS") }).strict(),
+  z.object({ kind: z.literal("ATTRIBUTION_FAILED") }).strict(),
+]);
+
+const targetSchema = z
+  .object({
+    targetType: z.string(),
+    publicId: z.string(),
+  })
+  .strict();
+
+const availableEventFields = {
+  eventVersion: z.literal(1),
+  occurredAt: z.string().datetime(),
+  outcome: z.enum(["SUCCESS", "FAILURE"]),
+  actor: actorSchema,
+  traceId: z.string().nullable(),
+  targets: z.array(targetSchema),
+};
+
+const profileMaterialUpdatedEventSchema = z
+  .object({
+    ...availableEventFields,
+    eventType: z.literal("company.profile.material_updated"),
+    details: z
+      .object({
+        changes: z.array(
+          z
+            .object({
+              field: z.enum(["name", "country", "taxNumber", "commercialNumber"]),
+              before: z.string().nullable(),
+              after: z.string().nullable(),
+            })
+            .strict(),
+        ),
+      })
+      .strict(),
+  })
+  .strict();
+
+const profileCompletedEventSchema = z
+  .object({
+    ...availableEventFields,
+    eventType: z.literal("company.profile.completed"),
+    details: z
+      .object({
+        beforeStatus: z.enum(["INCOMPLETE", "COMPLETE"]),
+        afterStatus: z.literal("COMPLETE"),
+      })
+      .strict(),
+  })
+  .strict();
+
+// Retained history the backend could not project — an unsupported event version or damaged
+// data. It arrives as an honest placeholder instead of raw, unprojected event fields.
+const unavailableEventSchema = z
+  .object({
+    eventType: z.literal("audit.event.unavailable"),
+    eventVersion: z.literal(1),
+    occurredAt: z.string().datetime(),
+    reason: z.literal("UNSUPPORTED_OR_DAMAGED"),
+  })
+  .strict();
+
+const companyPageSchema = z
+  .object({
+    items: z.array(
+      z.discriminatedUnion("eventType", [
+        profileMaterialUpdatedEventSchema,
+        profileCompletedEventSchema,
+        unavailableEventSchema,
+      ]),
+    ),
+    nextCursor: z.string().nullable(),
+    hasMore: z.boolean(),
+  })
+  .strict();
+
+export function parseCompanyAuditTrailPage(value: unknown): CompanyAuditTrailPage {
+  return companyPageSchema.parse(value);
+}

--- a/src/pages/company/audit/api/audit.test.ts
+++ b/src/pages/company/audit/api/audit.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { components } from "@/shared/api";
+import { apiClient } from "@/shared/api";
+import { fetchCompanyAuditTrail } from "./audit";
+
+const page: components["schemas"]["CompanyAuditTrailPage"] = {
+  items: [
+    {
+      eventType: "company.profile.completed",
+      eventVersion: 1,
+      occurredAt: "2026-08-13T10:00:00.000Z",
+      outcome: "SUCCESS",
+      actor: { kind: "USER", publicId: "550e8400-e29b-41d4-a716-446655440000" },
+      traceId: "5fc21e3361b0fe234353b1176c5b2fdf",
+      targets: [{ targetType: "company-profile", publicId: "profile-1" }],
+      details: { beforeStatus: "INCOMPLETE", afterStatus: "COMPLETE" },
+    },
+  ],
+  nextCursor: "opaque-next",
+  hasMore: true,
+};
+
+describe("fetchCompanyAuditTrail", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("calls the Company route and forwards only cursor and limit", async () => {
+    const get = mockAuditResponse(page);
+
+    await fetchCompanyAuditTrail({ cursor: "opaque-prev", limit: 25 });
+
+    const call = get.mock.calls[0];
+    expect(call?.[0]).toBe("company/audit-trail");
+    expect(call?.[1]).toMatchObject({ searchParams: { cursor: "opaque-prev", limit: "25" } });
+  });
+
+  it("asks for the first page when no paging input is given", async () => {
+    const get = mockAuditResponse(page);
+
+    await fetchCompanyAuditTrail({});
+
+    expect(get.mock.calls[0]?.[1]).toMatchObject({ searchParams: {} });
+  });
+
+  it("returns the parsed page with the opaque cursor preserved", async () => {
+    mockAuditResponse(page);
+
+    const parsed = await fetchCompanyAuditTrail({});
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.nextCursor).toBe("opaque-next");
+    expect(parsed.hasMore).toBe(true);
+  });
+
+  it("throws when the response is not a valid Company Audit Trail page", async () => {
+    mockAuditResponse({ items: "not-an-array" });
+
+    await expect(fetchCompanyAuditTrail({})).rejects.toThrow();
+  });
+});
+
+function mockAuditResponse(response: unknown) {
+  // Ky's response exposes more methods than this network-seam test exercises.
+  return vi.spyOn(apiClient, "get").mockReturnValue({
+    json: async () => response,
+  } as never);
+}

--- a/src/pages/company/audit/api/audit.ts
+++ b/src/pages/company/audit/api/audit.ts
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+import type { components } from "@/shared/api";
+import { apiClient } from "@/shared/api";
+import { parseCompanyAuditTrailPage } from "./audit-runtime-contract";
+
+export type CompanyAuditTrailEvent =
+  components["schemas"]["CompanyAuditTrailPage"]["items"][number];
+export type CompanyAuditTrailPage = components["schemas"]["CompanyAuditTrailPage"];
+
+/**
+ * Paging inputs for the Company Audit Trail. The Company route derives its scope from the
+ * authenticated identity, so there is deliberately no Company or scope filter to pass.
+ */
+export interface CompanyAuditTrailParams {
+  cursor?: string;
+  limit?: number;
+}
+
+export const companyAuditTrailKeys = {
+  page: (params: CompanyAuditTrailParams) => ["audit-trail", "company", params] as const,
+};
+
+/** Reads one cursor page and validates it here, so no component ever sees unparsed audit data. */
+export async function fetchCompanyAuditTrail(
+  params: CompanyAuditTrailParams,
+): Promise<CompanyAuditTrailPage> {
+  const searchParams: Record<string, string> = {};
+  if (params.cursor) searchParams.cursor = params.cursor;
+  if (params.limit) searchParams.limit = String(params.limit);
+
+  const response: unknown = await apiClient.get("company/audit-trail", { searchParams }).json();
+
+  return parseCompanyAuditTrailPage(response);
+}
+
+export function useCompanyAuditTrail(params: CompanyAuditTrailParams = {}) {
+  return useQuery({
+    queryKey: companyAuditTrailKeys.page(params),
+    queryFn: () => fetchCompanyAuditTrail(params),
+  });
+}

--- a/src/pages/company/audit/index.ts
+++ b/src/pages/company/audit/index.ts
@@ -1,0 +1,1 @@
+export { CompanyAuditPage } from "./ui/company-audit-page";

--- a/src/pages/company/audit/ui/company-audit-page.test.tsx
+++ b/src/pages/company/audit/ui/company-audit-page.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CompanyAuditTrailEvent, CompanyAuditTrailPage } from "../api/audit";
+import { CompanyAuditPage } from "./company-audit-page";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const apiGetMock = vi.hoisted(() => vi.fn());
+const searchState = vi.hoisted(() => ({ limit: 50 }) as Record<string, unknown>);
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useSearch: () => searchState,
+  };
+});
+
+// `ky` (the apiClient's HTTP layer) constructs AbortSignals that jsdom's fetch
+// rejects as cross-realm — stub the client boundary instead of the network.
+vi.mock("@/shared/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api")>()),
+  apiClient: { get: apiGetMock },
+}));
+
+const profileUpdatedEvent: CompanyAuditTrailEvent = {
+  eventType: "company.profile.material_updated",
+  eventVersion: 1,
+  occurredAt: "2026-08-13T10:00:00.000Z",
+  outcome: "SUCCESS",
+  actor: { kind: "USER", publicId: "550e8400-e29b-41d4-a716-446655440000" },
+  traceId: "5fc21e3361b0fe234353b1176c5b2fdf",
+  targets: [{ targetType: "company-profile", publicId: "profile-1" }],
+  details: { changes: [{ field: "name", before: "Northwind", after: "Northwind Egypt" }] },
+};
+
+function renderPage(page: Partial<CompanyAuditTrailPage> = {}) {
+  apiGetMock.mockReturnValue({
+    json: () => Promise.resolve({ items: [], nextCursor: null, hasMore: false, ...page }),
+  });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CompanyAuditPage />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  apiGetMock.mockReset();
+  navigateMock.mockReset();
+  delete searchState.cursor;
+});
+
+describe("CompanyAuditPage", () => {
+  it("reads the Company Audit Trail and lists its events", async () => {
+    renderPage({ items: [profileUpdatedEvent] });
+
+    expect(await screen.findByText("company.profile.material_updated")).toBeInTheDocument();
+    expect(apiGetMock.mock.calls[0]?.[0]).toBe("company/audit-trail");
+  });
+
+  it("tells the reader when the Company has no recorded events", async () => {
+    renderPage({ items: [] });
+
+    expect(await screen.findByText("No audit events")).toBeInTheDocument();
+  });
+
+  it("renders history it cannot project as unavailable rather than inventing facts", async () => {
+    renderPage({
+      items: [
+        {
+          eventType: "audit.event.unavailable",
+          eventVersion: 1,
+          occurredAt: "2026-08-13T10:01:00.000Z",
+          reason: "UNSUPPORTED_OR_DAMAGED",
+        },
+      ],
+    });
+
+    expect(await screen.findByText("Unavailable event")).toBeInTheDocument();
+    expect(screen.queryByText("audit.event.unavailable")).not.toBeInTheDocument();
+  });
+});
+
+describe("CompanyAuditPage cursor navigation", () => {
+  it("offers only the forward step on the first page", async () => {
+    renderPage({ items: [profileUpdatedEvent], nextCursor: "opaque-next", hasMore: true });
+
+    expect(await screen.findByRole("button", { name: "Older events" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Latest events" })).not.toBeInTheDocument();
+  });
+
+  it("offers both steps on a middle page and follows the opaque cursor forward", async () => {
+    searchState.cursor = "opaque-current";
+    renderPage({ items: [profileUpdatedEvent], nextCursor: "opaque-next", hasMore: true });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Older events" }));
+
+    expect(screen.getByRole("button", { name: "Latest events" })).toBeInTheDocument();
+    expect(readNavigatedSearch()).toEqual({ limit: 50, cursor: "opaque-next" });
+  });
+
+  it("drops the cursor entirely when returning to the latest events", async () => {
+    searchState.cursor = "opaque-current";
+    renderPage({ items: [profileUpdatedEvent], nextCursor: null, hasMore: false });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Latest events" }));
+
+    expect(readNavigatedSearch()).toEqual({ limit: 50 });
+  });
+
+  it("stops offering the forward step on the final page", async () => {
+    searchState.cursor = "opaque-current";
+    renderPage({ items: [profileUpdatedEvent], nextCursor: null, hasMore: false });
+
+    expect(await screen.findByRole("button", { name: "Latest events" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Older events" })).not.toBeInTheDocument();
+  });
+
+  it("offers no navigation on an empty first page", async () => {
+    renderPage({ items: [] });
+
+    expect(await screen.findByText("No audit events")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Older events" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Latest events" })).not.toBeInTheDocument();
+  });
+});
+
+/** Applies the search updater the page passed to `navigate` to the current search state. */
+function readNavigatedSearch() {
+  const updateSearch = navigateMock.mock.calls[0]?.[0]?.search;
+  return updateSearch({ ...searchState });
+}

--- a/src/pages/company/audit/ui/company-audit-page.tsx
+++ b/src/pages/company/audit/ui/company-audit-page.tsx
@@ -1,0 +1,186 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { ChevronLeft, ChevronRight, Shield } from "lucide-react";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { Card, CardContent } from "@/shared/ui/card";
+import { type CompanyAuditTrailEvent, useCompanyAuditTrail } from "../api/audit";
+
+type UnavailableEvent = Extract<CompanyAuditTrailEvent, { eventType: "audit.event.unavailable" }>;
+
+function isUnavailable(event: CompanyAuditTrailEvent): event is UnavailableEvent {
+  return event.eventType === "audit.event.unavailable";
+}
+
+function eventLabel(event: CompanyAuditTrailEvent): string {
+  return isUnavailable(event) ? "Unavailable event" : event.eventType;
+}
+
+function eventOutcome(event: CompanyAuditTrailEvent): "SUCCESS" | "FAILURE" | null {
+  return isUnavailable(event) ? null : event.outcome;
+}
+
+function eventActor(event: CompanyAuditTrailEvent): string {
+  if (isUnavailable(event)) return "—";
+  return event.actor.kind.replace("_", " ").toLowerCase();
+}
+
+function eventOccurredAt(event: CompanyAuditTrailEvent): string {
+  return new Date(event.occurredAt).toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function AuditTable({ items }: { items: CompanyAuditTrailEvent[] }) {
+  return (
+    <div className="scrollbar-calm overflow-x-auto">
+      <table className="w-full min-w-[640px]">
+        <thead>
+          <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface-2)]">
+            {["Event", "Actor", "Outcome", "Timestamp"].map((header) => (
+              <th
+                key={header}
+                className="px-4 py-2.5 text-start text-[11px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]"
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((event, index) => {
+            const outcome = eventOutcome(event);
+            return (
+              <tr
+                key={`${event.eventType}-${event.occurredAt}-${index}`}
+                className="border-b border-[var(--color-border)] transition-colors last:border-b-0 hover:bg-[var(--color-surface-2)]"
+              >
+                <td className="px-4 py-3">
+                  <code className="text-[12.5px] font-mono text-[var(--color-text)]">
+                    {eventLabel(event)}
+                  </code>
+                </td>
+                <td className="px-4 py-3 text-[12.5px] text-[var(--color-text-muted)]">
+                  {eventActor(event)}
+                </td>
+                <td className="px-4 py-3">
+                  {outcome ? (
+                    <Badge variant={outcome === "SUCCESS" ? "success" : "danger"}>
+                      {outcome === "SUCCESS" ? "Success" : "Failure"}
+                    </Badge>
+                  ) : (
+                    <span className="text-[var(--color-text-faint)]">–</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-[12.5px] tabular-nums text-[var(--color-text-muted)]">
+                  {eventOccurredAt(event)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function EmptyState({ message, action }: { message: string; action?: React.ReactNode }) {
+  return (
+    <div className="flex flex-col items-center gap-2 py-16 text-center">
+      <Shield size={32} className="text-[var(--color-text-faint)]" />
+      <p className="text-sm font-medium text-[var(--color-text-muted)]">{message}</p>
+      {action}
+    </div>
+  );
+}
+
+export function CompanyAuditPage() {
+  const { cursor, limit } = useSearch({ from: "/company/audit/" });
+  const navigate = useNavigate({ from: "/company/audit/" });
+  const query = useCompanyAuditTrail({ cursor, limit });
+
+  const page = query.data;
+  const items = page?.items ?? [];
+  const nextCursor = page?.nextCursor ?? null;
+  const canGoOlder = (page?.hasMore ?? false) && nextCursor !== null;
+
+  function goToOlderEvents() {
+    if (!nextCursor) return;
+    void navigate({ search: (previous) => ({ ...previous, cursor: nextCursor }) });
+  }
+
+  // The trail has no page numbers to count back through, so the only backward step the
+  // opaque cursor supports is dropping it and returning to the newest page.
+  function goToLatestEvents() {
+    void navigate({
+      search: ({ cursor: _cursor, ...rest }) => rest,
+    });
+  }
+
+  return (
+    <div className="mx-auto max-w-[1480px]">
+      <div className="mb-6">
+        <h1 className="text-[26px] font-bold tracking-tight text-[var(--color-text)]">Audit log</h1>
+        <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+          Your company's retained event history
+        </p>
+      </div>
+
+      <Card className="overflow-hidden">
+        <CardContent className="p-0">
+          {query.isPending ? (
+            <EmptyState message="Loading audit trail…" />
+          ) : query.isError ? (
+            <EmptyState
+              message="Audit trail could not be loaded"
+              action={
+                <Button intent="utility" size="sm" onClick={() => query.refetch()}>
+                  Retry
+                </Button>
+              }
+            />
+          ) : items.length === 0 ? (
+            <EmptyState message="No audit events" />
+          ) : (
+            <AuditTable items={items} />
+          )}
+        </CardContent>
+        {items.length > 0 && (
+          <div className="flex items-center justify-between gap-3 border-t border-[var(--color-border)] px-4 py-3">
+            <span className="text-xs text-[var(--color-text-muted)]">
+              {items.length} event{items.length === 1 ? "" : "s"}
+            </span>
+            <div className="flex items-center gap-1">
+              {cursor && (
+                <Button
+                  variant="nav"
+                  size="iconXs"
+                  className="btn-nav-prev"
+                  onClick={goToLatestEvents}
+                  aria-label="Latest events"
+                  title="Latest events"
+                >
+                  <ChevronLeft size={14} />
+                </Button>
+              )}
+              {canGoOlder && (
+                <Button
+                  variant="nav"
+                  size="iconXs"
+                  className="btn-nav-next"
+                  onClick={goToOlderEvents}
+                  aria-label="Older events"
+                  title="Older events"
+                >
+                  <ChevronRight size={14} />
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as CompanySetupIndexRouteImport } from "./app/routes/company/setu
 import { Route as CompanyProfileIndexRouteImport } from "./app/routes/company/profile/index"
 import { Route as CompanyEmailSettingsIndexRouteImport } from "./app/routes/company/email-settings/index"
 import { Route as CompanyDashboardIndexRouteImport } from "./app/routes/company/dashboard/index"
+import { Route as CompanyAuditIndexRouteImport } from "./app/routes/company/audit/index"
 import { Route as AdminSubscriptionsIndexRouteImport } from "./app/routes/admin/subscriptions/index"
 import { Route as AdminPlansIndexRouteImport } from "./app/routes/admin/plans/index"
 import { Route as AdminLeadsIndexRouteImport } from "./app/routes/admin/leads/index"
@@ -114,6 +115,11 @@ const CompanyEmailSettingsIndexRoute =
 const CompanyDashboardIndexRoute = CompanyDashboardIndexRouteImport.update({
   id: "/dashboard/",
   path: "/dashboard/",
+  getParentRoute: () => CompanyRouteRoute,
+} as any)
+const CompanyAuditIndexRoute = CompanyAuditIndexRouteImport.update({
+  id: "/audit/",
+  path: "/audit/",
   getParentRoute: () => CompanyRouteRoute,
 } as any)
 const AdminSubscriptionsIndexRoute = AdminSubscriptionsIndexRouteImport.update({
@@ -222,6 +228,7 @@ export interface FileRoutesByFullPath {
   "/admin/leads/": typeof AdminLeadsIndexRoute
   "/admin/plans/": typeof AdminPlansIndexRoute
   "/admin/subscriptions/": typeof AdminSubscriptionsIndexRoute
+  "/company/audit/": typeof CompanyAuditIndexRoute
   "/company/dashboard/": typeof CompanyDashboardIndexRoute
   "/company/email-settings/": typeof CompanyEmailSettingsIndexRoute
   "/company/profile/": typeof CompanyProfileIndexRoute
@@ -250,6 +257,7 @@ export interface FileRoutesByTo {
   "/admin/leads": typeof AdminLeadsIndexRoute
   "/admin/plans": typeof AdminPlansIndexRoute
   "/admin/subscriptions": typeof AdminSubscriptionsIndexRoute
+  "/company/audit": typeof CompanyAuditIndexRoute
   "/company/dashboard": typeof CompanyDashboardIndexRoute
   "/company/email-settings": typeof CompanyEmailSettingsIndexRoute
   "/company/profile": typeof CompanyProfileIndexRoute
@@ -283,6 +291,7 @@ export interface FileRoutesById {
   "/admin/leads/": typeof AdminLeadsIndexRoute
   "/admin/plans/": typeof AdminPlansIndexRoute
   "/admin/subscriptions/": typeof AdminSubscriptionsIndexRoute
+  "/company/audit/": typeof CompanyAuditIndexRoute
   "/company/dashboard/": typeof CompanyDashboardIndexRoute
   "/company/email-settings/": typeof CompanyEmailSettingsIndexRoute
   "/company/profile/": typeof CompanyProfileIndexRoute
@@ -317,6 +326,7 @@ export interface FileRouteTypes {
     | "/admin/leads/"
     | "/admin/plans/"
     | "/admin/subscriptions/"
+    | "/company/audit/"
     | "/company/dashboard/"
     | "/company/email-settings/"
     | "/company/profile/"
@@ -345,6 +355,7 @@ export interface FileRouteTypes {
     | "/admin/leads"
     | "/admin/plans"
     | "/admin/subscriptions"
+    | "/company/audit"
     | "/company/dashboard"
     | "/company/email-settings"
     | "/company/profile"
@@ -377,6 +388,7 @@ export interface FileRouteTypes {
     | "/admin/leads/"
     | "/admin/plans/"
     | "/admin/subscriptions/"
+    | "/company/audit/"
     | "/company/dashboard/"
     | "/company/email-settings/"
     | "/company/profile/"
@@ -501,6 +513,13 @@ declare module "@tanstack/react-router" {
       path: "/dashboard"
       fullPath: "/company/dashboard/"
       preLoaderRoute: typeof CompanyDashboardIndexRouteImport
+      parentRoute: typeof CompanyRouteRoute
+    }
+    "/company/audit/": {
+      id: "/company/audit/"
+      path: "/audit"
+      fullPath: "/company/audit/"
+      preLoaderRoute: typeof CompanyAuditIndexRouteImport
       parentRoute: typeof CompanyRouteRoute
     }
     "/admin/subscriptions/": {
@@ -691,6 +710,7 @@ const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
 )
 
 interface CompanyRouteRouteChildren {
+  CompanyAuditIndexRoute: typeof CompanyAuditIndexRoute
   CompanyDashboardIndexRoute: typeof CompanyDashboardIndexRoute
   CompanyEmailSettingsIndexRoute: typeof CompanyEmailSettingsIndexRoute
   CompanyProfileIndexRoute: typeof CompanyProfileIndexRoute
@@ -698,6 +718,7 @@ interface CompanyRouteRouteChildren {
 }
 
 const CompanyRouteRouteChildren: CompanyRouteRouteChildren = {
+  CompanyAuditIndexRoute: CompanyAuditIndexRoute,
   CompanyDashboardIndexRoute: CompanyDashboardIndexRoute,
   CompanyEmailSettingsIndexRoute: CompanyEmailSettingsIndexRoute,
   CompanyProfileIndexRoute: CompanyProfileIndexRoute,

--- a/src/widgets/app-shell/model/nav-items.test.tsx
+++ b/src/widgets/app-shell/model/nav-items.test.tsx
@@ -1,10 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { adminNavGroups } from "./nav-items";
+import { adminNavGroups, companyNavGroups } from "./nav-items";
 
 describe("Admin navigation", () => {
   it("exposes the Email Platform area", () => {
     expect(adminNavGroups.flatMap((group) => group.items)).toEqual(
       expect.arrayContaining([expect.objectContaining({ label: "Email", href: "/admin/email" })]),
+    );
+  });
+});
+
+describe("Company navigation", () => {
+  it("reaches the Company Audit Trail", () => {
+    expect(companyNavGroups.flatMap((group) => group.items)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Audit log", href: "/company/audit" }),
+      ]),
     );
   });
 });

--- a/src/widgets/app-shell/model/nav-items.tsx
+++ b/src/widgets/app-shell/model/nav-items.tsx
@@ -151,6 +151,11 @@ export const companyNavGroups: NavGroup[] = [
         href: "/company/reports",
         icon: <BarChart3 size={ICON_SIZE} />,
       },
+      {
+        label: "Audit log",
+        href: "/company/audit",
+        icon: <Shield size={ICON_SIZE} />,
+      },
     ],
   },
 ];


### PR DESCRIPTION
Delivers the Company Portal Audit Trail. Backend counterpart: Edara-Solutions/HRMS_Back_End#167 (merged). Tracking issue: Edara-Solutions/HRMS_Back_End#147.

## What this adds

The Company Portal had no audit history at all — no route, no page, no runtime contract. This adds them against the canonical Company route and the generated `CompanyAuditTrailPage`.

**Platform-only identity is unrepresentable, not merely unrendered.** The runtime contract admits a `PLATFORM_ADMIN` actor carrying no identifier and `.strict()`-rejects one that arrives with a public id, so a Company reader learns *that* Edara acted without learning *which* administrator did. There is deliberately no Company or scope filter to pass — the route derives scope from the authenticated identity.

**Unavailable history renders honestly.** Retained events the backend could not project arrive as `audit.event.unavailable` and render as a placeholder rather than raw, unprojected fields.

**Paging is purely by opaque cursor.** The trail has no page numbers to count back through, so the only backward step is dropping the cursor and returning to the newest page.

## Acceptance criteria

- [x] Company Portal consumes only the Company Audit Trail route and generated runtime validator — response parsed once inside the query function; no component sees unparsed data
- [x] Components receive validated Company page values and cannot represent Platform-only actor fields or filters
- [x] Cursor navigation handles empty, first, middle, and final pages without page-number assumptions
- [x] Functional tests prove Company isolation and audience-safe unavailable history rendering

## Verification

`typecheck` ✓ · `lint` ✓ (biome + steiger) · `test` ✓ 209 passed (39 files) · `build` ✓

23 new tests, including:
- `rejects a Platform Admin actor carrying a public identifier` (isolation)
- `renders history it cannot project as unavailable rather than inventing facts`
- `offers no navigation on an empty first page` / `only the forward step on the first page` / `both steps on a middle page` / `stops offering the forward step on the final page`


