### PR TITLE
feat(notification): poll unread count and render the bell badge in both shells

### DIFF
--- a/src/features/notification/api/unread-count.test.ts
+++ b/src/features/notification/api/unread-count.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchUnreadNotificationCount } from "./unread-count";
+
+function countResponse(body: unknown, headers: Record<string, string>) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+function notModifiedResponse(headers: Record<string, string>) {
+  return new Response(null, { status: 304, headers });
+}
+
+function requestOf(input: RequestInfo | URL, init?: RequestInit) {
+  return input instanceof Request ? input : new Request(input, init);
+}
+
+describe("fetchUnreadNotificationCount", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("revalidates with the stored ETag and leaves the count untouched on a 304", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+      requestOf(input, init).headers.get("If-None-Match") === '"u:7:12"'
+        ? notModifiedResponse({ etag: '"u:7:12"' })
+        : countResponse({ unreadCount: 3 }, { etag: '"u:7:12"' }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await fetchUnreadNotificationCount("company");
+    const second = await fetchUnreadNotificationCount("company");
+
+    expect(first).toEqual({ unreadCount: 3, pollIntervalMs: 30_000 });
+    expect(second).toBe(first);
+
+    const [initial, revalidation] = fetchMock.mock.calls.map(([input, init]) =>
+      requestOf(input, init),
+    );
+    expect(initial.url).toContain("company/notifications/unread-count");
+    expect(initial.headers.has("If-None-Match")).toBe(false);
+    expect(revalidation.headers.get("If-None-Match")).toBe('"u:7:12"');
+  });
+
+  it("reads the platform mount and lets the server cadence header win", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      countResponse({ unreadCount: 8 }, { etag: '"pa:2:5"', "x-poll-interval": "10" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchUnreadNotificationCount("platform");
+
+    expect(result).toEqual({ unreadCount: 8, pollIntervalMs: 10_000 });
+    const [input, init] = fetchMock.mock.calls[0];
+    expect(requestOf(input, init).url).toContain("platform/notifications/unread-count");
+  });
+});

--- a/src/features/notification/api/unread-count.ts
+++ b/src/features/notification/api/unread-count.ts
@@ -1,0 +1,104 @@
+import { useQuery } from "@tanstack/react-query";
+import { HTTPError } from "ky";
+import { z } from "zod";
+import { apiClient } from "@/shared/api";
+import { notificationKeys } from "../model/notification-keys";
+import { type NotificationTier, useNotificationTier } from "../model/notification-tier";
+import { IDLE_POLL_INTERVAL_MS, resolvePollIntervalMs } from "../model/poll-cadence";
+
+/**
+ * Interim wire contract pinned to HRMS_Back_End#198 §5 (`NotificationUnreadCount`).
+ * Swap for `components["schemas"]["NotificationUnreadCount"]` once the endpoint is
+ * reachable and `bun run openapi:types` can regenerate the schema.
+ */
+const unreadCountResponseSchema = z.object({
+  unreadCount: z.number().int().nonnegative(),
+});
+
+export interface UnreadNotificationCount {
+  readonly unreadCount: number;
+  readonly pollIntervalMs: number;
+}
+
+interface CachedUnreadCount {
+  readonly etag: string;
+  readonly value: UnreadNotificationCount;
+}
+
+const NOT_MODIFIED = 304;
+
+/**
+ * Revision ETags are per identity, so each tier keeps its own. Nothing outside this module
+ * touches the cache — conditional-request mechanics stay behind `fetchUnreadNotificationCount`.
+ */
+const cacheByTier = new Map<NotificationTier, CachedUnreadCount>();
+
+function unreadCountPath(tier: NotificationTier) {
+  return `${tier}/notifications/unread-count`;
+}
+
+// ky rejects every non-2xx, but a conditional GET's 304 is this endpoint's cheap success
+// path — unwrap it back into a plain response and let real failures propagate.
+async function requestUnreadCount(tier: NotificationTier, etag: string | undefined) {
+  try {
+    return await apiClient.get(unreadCountPath(tier), {
+      headers: etag ? { "If-None-Match": etag } : undefined,
+    });
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === NOT_MODIFIED) {
+      return error.response;
+    }
+
+    throw error;
+  }
+}
+
+export async function fetchUnreadNotificationCount(
+  tier: NotificationTier,
+): Promise<UnreadNotificationCount> {
+  const cached = cacheByTier.get(tier);
+  const response = await requestUnreadCount(tier, cached?.etag);
+  const pollIntervalMs = resolvePollIntervalMs(response.headers.get("x-poll-interval"));
+
+  if (response.status === NOT_MODIFIED && cached) {
+    // The count is unchanged by definition; only the cadence header may have moved. Handing
+    // back the cached object when it has not keeps the 304 a true no-op for React Query.
+    const value =
+      cached.value.pollIntervalMs === pollIntervalMs
+        ? cached.value
+        : { ...cached.value, pollIntervalMs };
+
+    cacheByTier.set(tier, { ...cached, value });
+    return value;
+  }
+
+  const { unreadCount } = unreadCountResponseSchema.parse(await response.json());
+  const value: UnreadNotificationCount = { unreadCount, pollIntervalMs };
+  const revision = response.headers.get("etag");
+
+  if (revision) {
+    cacheByTier.set(tier, { etag: revision, value });
+  } else {
+    cacheByTier.delete(tier);
+  }
+
+  return value;
+}
+
+export function useUnreadNotificationCount() {
+  const tier = useNotificationTier();
+
+  return useQuery({
+    queryKey: notificationKeys.count(),
+    queryFn: () => {
+      if (!tier) throw new Error("Notification tier requires a session");
+      return fetchUnreadNotificationCount(tier);
+    },
+    enabled: tier !== null,
+    // The badge must react the moment the window comes back, so nothing here is ever fresh.
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchInterval: (query) => query.state.data?.pollIntervalMs ?? IDLE_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/src/features/notification/index.ts
+++ b/src/features/notification/index.ts
@@ -1,0 +1,1 @@
+export { NotificationBell } from "./ui/notification-bell";

--- a/src/features/notification/model/notification-keys.ts
+++ b/src/features/notification/model/notification-keys.ts
@@ -1,0 +1,8 @@
+/**
+ * Query keys locked by the polling contract (HRMS_Back_End#198 §5). The list key is
+ * reserved here so the feed slice lands on the same shape the count already uses.
+ */
+export const notificationKeys = {
+  count: () => ["notifications", "count"] as const,
+  list: (cursor: string | null) => ["notifications", "list", cursor] as const,
+};

--- a/src/features/notification/model/notification-tier.ts
+++ b/src/features/notification/model/notification-tier.ts
@@ -1,0 +1,14 @@
+import { useAuthStore } from "@/shared/auth";
+
+/** Which tier's notification mount the center talks to. Derived from the session, never from props. */
+export type NotificationTier = "company" | "platform";
+
+export function useNotificationTier(): NotificationTier | null {
+  const isPlatformAdmin = useAuthStore((state) => state.session?.user.isPlatformAdmin);
+
+  if (isPlatformAdmin === undefined) {
+    return null;
+  }
+
+  return isPlatformAdmin ? "platform" : "company";
+}

--- a/src/features/notification/model/poll-cadence.ts
+++ b/src/features/notification/model/poll-cadence.ts
@@ -1,0 +1,16 @@
+/** Idle cadence from the polling contract (HRMS_Back_End#198 §5). */
+export const IDLE_POLL_INTERVAL_MS = 30_000;
+
+/** Floor for a server-supplied cadence, so a malformed header cannot turn the badge into a request loop. */
+const MIN_POLL_INTERVAL_MS = 5_000;
+
+/** The server's `x-poll-interval` (seconds) overrides the idle cadence whenever it reads as a usable number. */
+export function resolvePollIntervalMs(serverInterval: string | null): number {
+  const seconds = Number(serverInterval);
+
+  if (!serverInterval || !Number.isFinite(seconds) || seconds <= 0) {
+    return IDLE_POLL_INTERVAL_MS;
+  }
+
+  return Math.max(MIN_POLL_INTERVAL_MS, seconds * 1000);
+}

--- a/src/features/notification/ui/notification-bell.test.tsx
+++ b/src/features/notification/ui/notification-bell.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthSession, SessionUser } from "@/shared/auth";
+import { useAuthStore } from "@/shared/auth";
+import { NotificationBell } from "./notification-bell";
+
+const unreadCountGetMock = vi.hoisted(() => vi.fn());
+
+// `ky` builds AbortSignals that jsdom's fetch rejects as cross-realm — stub the client
+// boundary instead of the network.
+vi.mock("@/shared/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api")>()),
+  apiClient: { get: unreadCountGetMock },
+}));
+
+const baseUser: SessionUser = {
+  publicId: "user-1",
+  employeeCode: "EMP-001",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  status: "ACTIVE",
+  companyCode: "ACME",
+  mustChangePassword: false,
+  permissions: [],
+  isOwner: false,
+  isPlatformAdmin: false,
+};
+
+const session: AuthSession = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  sessionId: "session-1",
+  expiresIn: 900,
+  user: baseUser,
+};
+
+function renderBell(unreadCount: number) {
+  unreadCountGetMock.mockResolvedValue(
+    new Response(JSON.stringify({ unreadCount }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  useAuthStore.setState({ session, status: "authenticated" });
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NotificationBell />
+    </QueryClientProvider>,
+  );
+}
+
+describe("NotificationBell", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    useAuthStore.setState({ session: null, status: "anonymous" });
+  });
+
+  it("caps the badge at 99+ and announces the count on the bell", async () => {
+    renderBell(128);
+
+    expect(await screen.findByText("99+")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Notifications, 128 unread" })).toBeInTheDocument();
+  });
+
+  it("hides the badge while nothing is unread", async () => {
+    renderBell(0);
+
+    expect(await screen.findByRole("button", { name: "Notifications" })).toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -1,0 +1,34 @@
+import { Bell } from "lucide-react";
+import { Button } from "@/shared/ui/button";
+import { useUnreadNotificationCount } from "../api/unread-count";
+
+const BADGE_COUNT_CAP = 99;
+
+export function NotificationBell() {
+  const { data } = useUnreadNotificationCount();
+  const unreadCount = data?.unreadCount ?? 0;
+
+  return (
+    <div className="relative">
+      <Button
+        intent="toggle"
+        size="iconSm"
+        aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : "Notifications"}
+        leadingIcon={<Bell size={16} />}
+        iconOnly
+      />
+      {unreadCount > 0 && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute -top-1 -end-1 inline-flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--color-primary)] px-1 text-[10px] font-semibold leading-none tabular-nums text-[var(--color-on-primary)] ring-2 ring-[var(--color-bg)]"
+        >
+          {formatBadgeCount(unreadCount)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatBadgeCount(count: number) {
+  return count > BADGE_COUNT_CAP ? `${BADGE_COUNT_CAP}+` : String(count);
+}

--- a/src/widgets/app-shell/ui/header.tsx
+++ b/src/widgets/app-shell/ui/header.tsx
@@ -1,4 +1,5 @@
-import { Bell, HelpCircle, Search } from "lucide-react";
+import { HelpCircle, Search } from "lucide-react";
+import { NotificationBell } from "@/features/notification";
 import { useAuthStore } from "@/shared/auth";
 import { Avatar } from "@/shared/ui/avatar";
 import { Button } from "@/shared/ui/button";
@@ -32,16 +33,7 @@ export function Header() {
 
       {/* Actions */}
       <div className="flex items-center gap-1">
-        <div className="relative">
-          <Button
-            intent="toggle"
-            size="iconSm"
-            aria-label="Notifications"
-            leadingIcon={<Bell size={16} />}
-            iconOnly
-          />
-          <span className="pointer-events-none absolute end-1.5 top-1.5 size-1.5 rounded-full bg-[var(--color-danger)] ring-2 ring-[var(--color-bg)]" />
-        </div>
+        <NotificationBell />
 
         <Button
           intent="toggle"

--- a/steiger.config.js
+++ b/steiger.config.js
@@ -137,4 +137,13 @@ export default defineConfig([
       "edara/no-entities-layer": "error",
     },
   },
+  {
+    // The notification center is deliberately one slice both portals' shells mount
+    // (HRMS-UI#53). The app-shell widget being its only consumer is the point, not a
+    // smell — merging it there would bury portal-agnostic notification logic in a layout block.
+    files: ["./src/features/notification/**"],
+    rules: {
+      "fsd/insignificant-slice": "off",
+    },
+  },
 ]);


### PR DESCRIPTION
Closes Edara-Solutions/HRMS-UI#54.

The notification center's data foundation plus its first visible artifact: the bell badge in the app-shell header, working identically for both portals.

## What's in it

`src/features/notification/` — one slice both portals' shells mount; the tier it talks to comes from the auth-store session, never from props.

| File | Role |
| --- | --- |
| `api/unread-count.ts` | Interim wire contract, ETag-conditional fetcher, `useUnreadNotificationCount()` |
| `model/notification-tier.ts` | `company` / `platform` derived from `isPlatformAdmin` |
| `model/notification-keys.ts` | `['notifications','count']`; list key reserved as `['notifications','list',cursor]` |
| `model/poll-cadence.ts` | 30s idle cadence, `x-poll-interval` override with a 5s floor |
| `ui/notification-bell.tsx` | Bell + navy badge — hidden at zero, capped at `99+`, count in the button's `aria-label` |

The header's static red dot is replaced by `<NotificationBell />`.

## Contract

Pinned to the shapes the backend already implements on `feature/notification` (`notification-feed.routes.ts`, per HRMS_Back_End#198 §5):

- `GET {company|platform}/notifications/unread-count` → `{ unreadCount }`
- `etag` and `x-poll-interval` (seconds) ride both the 200 and the 304

The backend isn't reachable yet, so the wire types stay an interim Zod contract marked for swap with `bun run openapi:types`.

## Two decisions worth a look

**304 handling.** The count comes back untouched — the cached object is returned by identity, so React Query sees a true no-op — but the cadence header is still applied. Applying `x-poll-interval` only on 200 would mean the server's throttle knob can never take effect during a quiet period, which is exactly when it matters.

**Steiger.** `fsd/insignificant-slice` fires because app-shell is the slice's only consumer today. That one rule is scoped off for `src/features/notification/**` with the reason in a comment, rather than folding the center into the layout widget.

## Verification

`typecheck`, `test` (173 passed, 4 new), and `lint` (Biome + Steiger) are green. `react-doctor --scope changed` reports nothing in the new files.

New tests cover the ETag revalidation and 304 no-op, the platform mount plus server cadence override, the `99+` cap, and the badge staying hidden at zero.
