### PR TITLE
feat(notification): render the notification panel from the live feed with catalog copy

### DIFF
--- a/public/locales/ar/notification.json
+++ b/public/locales/ar/notification.json
@@ -1,0 +1,62 @@
+{
+  "panel": {
+    "title": "الإشعارات",
+    "unread": "{{count}} غير مقروء",
+    "empty": {
+      "title": "لا جديد لديك",
+      "hint": "تظهر هنا الإشعارات المتعلقة بموظفيك والموافقات وحسابك."
+    },
+    "buckets": {
+      "today": "اليوم",
+      "yesterday": "أمس",
+      "earlier": "سابقاً"
+    },
+    "showOlder": "عرض الأقدم",
+    "loading": "جارٍ تحميل الإشعارات…",
+    "error": "تعذّر تحميل الإشعارات."
+  },
+  "values": {
+    "decision": {
+      "approved": "مقبول",
+      "rejected": "مرفوض"
+    }
+  },
+  "notifications": {
+    "platform": {
+      "lead-created": {
+        "title": "عميل محتمل جديد",
+        "body": "انضم عميل محتمل جديد إلى القائمة وهو جاهز للمراجعة."
+      },
+      "conversion-requested": {
+        "title": "طلب تحويل جديد",
+        "body": "هناك شركة في انتظار قرارك بشأن التحويل."
+      },
+      "company-activated": {
+        "title": "تم تفعيل الشركة",
+        "body": "شركتك الآن مفعّلة على إدارة."
+      },
+      "conversion-decided": {
+        "title": "طلب التحويل {{decision}}",
+        "body": "قامت إدارة بمراجعة طلب التحويل الخاص بك."
+      },
+      "announcement": {
+        "title": "إعلان",
+        "body": "تم نشر إعلان جديد."
+      }
+    },
+    "company": {
+      "subscription-changed": {
+        "title": "تم تحديث الاشتراك",
+        "body": "خطتك الآن {{planName}} ({{status}})."
+      },
+      "role-assigned": {
+        "title": "تم إسناد دور",
+        "body": "تم منحك دور {{roleName}}."
+      },
+      "user-joined": {
+        "title": "انضم عضو جديد",
+        "body": "تم قبول دعوة وانضم عضو جديد إلى شركتك."
+      }
+    }
+  }
+}

--- a/public/locales/en/notification.json
+++ b/public/locales/en/notification.json
@@ -1,0 +1,62 @@
+{
+  "panel": {
+    "title": "Notifications",
+    "unread": "{{count}} unread",
+    "empty": {
+      "title": "You're all caught up",
+      "hint": "Notifications about your people, approvals and account land here."
+    },
+    "buckets": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "earlier": "Earlier"
+    },
+    "showOlder": "Show older",
+    "loading": "Loading notifications…",
+    "error": "Notifications could not be loaded."
+  },
+  "values": {
+    "decision": {
+      "approved": "approved",
+      "rejected": "rejected"
+    }
+  },
+  "notifications": {
+    "platform": {
+      "lead-created": {
+        "title": "New lead registered",
+        "body": "A new lead joined the pipeline and is ready for review."
+      },
+      "conversion-requested": {
+        "title": "Conversion request submitted",
+        "body": "A company is waiting for your conversion decision."
+      },
+      "company-activated": {
+        "title": "Company activated",
+        "body": "Your company is now active on Edara."
+      },
+      "conversion-decided": {
+        "title": "Conversion request {{decision}}",
+        "body": "Edara has reviewed your conversion request."
+      },
+      "announcement": {
+        "title": "Announcement",
+        "body": "A new announcement was published."
+      }
+    },
+    "company": {
+      "subscription-changed": {
+        "title": "Subscription updated",
+        "body": "Your plan is now {{planName}} ({{status}})."
+      },
+      "role-assigned": {
+        "title": "Role assigned",
+        "body": "You were granted the {{roleName}} role."
+      },
+      "user-joined": {
+        "title": "New member joined",
+        "body": "An invitation was accepted and a new member joined your company."
+      }
+    }
+  }
+}

--- a/src/features/notification/api/notification-feed.test.tsx
+++ b/src/features/notification/api/notification-feed.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthSession, SessionUser } from "@/shared/auth";
+import { useAuthStore } from "@/shared/auth";
+import { useNotificationFeed } from "./notification-feed";
+
+const feedGetMock = vi.hoisted(() => vi.fn());
+
+// `ky` builds AbortSignals that jsdom's fetch rejects as cross-realm — stub the client boundary
+// instead of the network.
+vi.mock("@/shared/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api")>()),
+  apiClient: { get: feedGetMock },
+}));
+
+const baseUser: SessionUser = {
+  publicId: "user-1",
+  employeeCode: "EMP-001",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  status: "ACTIVE",
+  companyCode: "ACME",
+  mustChangePassword: false,
+  permissions: [],
+  isOwner: false,
+  isPlatformAdmin: false,
+};
+
+const session: AuthSession = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  sessionId: "session-1",
+  expiresIn: 900,
+  user: baseUser,
+};
+
+function feedItem(id: number, createdAt: string) {
+  return {
+    id,
+    scope: "company",
+    typeKey: "company.user-joined",
+    typeVersion: 1,
+    importance: "normal",
+    params: {},
+    actor: { kind: "system" },
+    subject: null,
+    createdAt,
+    seenAt: null,
+    readAt: null,
+  };
+}
+
+function feedPage(items: unknown[], nextCursor: string | null) {
+  return { json: async () => ({ items, nextCursor, hasMore: nextCursor !== null }) };
+}
+
+function searchParamsOf(call: number) {
+  return feedGetMock.mock.calls[call][1].searchParams as URLSearchParams;
+}
+
+function renderFeed(open: boolean) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return renderHook(({ isOpen }: { isOpen: boolean }) => useNotificationFeed(isOpen), {
+    wrapper,
+    initialProps: { isOpen: open },
+  });
+}
+
+describe("useNotificationFeed", () => {
+  beforeEach(() => {
+    useAuthStore.setState({ session, status: "authenticated" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ session: null, status: "anonymous" });
+  });
+
+  it("stays idle while the panel is closed", () => {
+    renderFeed(false);
+
+    expect(feedGetMock).not.toHaveBeenCalled();
+  });
+
+  it("pages by cursor at the contract limit and keeps one row per id", async () => {
+    feedGetMock
+      .mockReturnValueOnce(feedPage([feedItem(3, "2026-08-25T09:00:00.000Z")], "cursor-2"))
+      .mockReturnValueOnce(
+        feedPage(
+          [feedItem(3, "2026-08-25T09:00:00.000Z"), feedItem(2, "2026-08-24T09:00:00.000Z")],
+          null,
+        ),
+      );
+
+    const { result } = renderFeed(true);
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(searchParamsOf(0).get("limit")).toBe("20");
+    expect(searchParamsOf(0).has("cursor")).toBe(false);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(searchParamsOf(1).get("cursor")).toBe("cursor-2");
+    expect(result.current.data?.map((item) => item.id)).toEqual([3, 2]);
+  });
+
+  it("catches up on reopen with a since delta merged into the cached rows", async () => {
+    feedGetMock
+      .mockReturnValueOnce(feedPage([feedItem(1, "2026-08-25T09:00:00.000Z")], null))
+      .mockReturnValueOnce(feedPage([feedItem(5, "2026-08-25T10:00:00.000Z")], null));
+
+    const { result, rerender } = renderFeed(true);
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+
+    await act(async () => {
+      rerender({ isOpen: false });
+    });
+    await act(async () => {
+      rerender({ isOpen: true });
+    });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(2));
+    expect(searchParamsOf(1).get("since")).toBe("2026-08-25T09:00:00.000Z");
+    expect(result.current.data?.map((item) => item.id)).toEqual([5, 1]);
+  });
+});

--- a/src/features/notification/api/notification-feed.ts
+++ b/src/features/notification/api/notification-feed.ts
@@ -1,0 +1,140 @@
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { z } from "zod";
+import { apiClient } from "@/shared/api";
+import { notificationKeys } from "../model/notification-keys";
+import { type NotificationTier, useNotificationTier } from "../model/notification-tier";
+
+/**
+ * Interim wire contract pinned to HRMS_Back_End#198 §5 (`NotificationFeedPage`). Swap for
+ * `components["schemas"]["NotificationFeedPage"]` once the endpoint is reachable and
+ * `bun run openapi:types` can regenerate the schema.
+ */
+const feedItemSchema = z.object({
+  id: z.number().int(),
+  scope: z.enum(["company", "platform"]),
+  typeKey: z.string().min(1),
+  typeVersion: z.number().int(),
+  importance: z.enum(["high", "normal"]),
+  params: z.record(z.string(), z.unknown()),
+  actor: z.union([
+    z.object({ kind: z.literal("system") }),
+    z.object({ kind: z.enum(["user", "platform_admin"]), publicId: z.string() }),
+  ]),
+  subject: z.object({ type: z.string(), publicId: z.string() }).nullable(),
+  createdAt: z.string().min(1),
+  seenAt: z.string().nullable(),
+  readAt: z.string().nullable(),
+});
+
+const feedPageSchema = z.object({
+  items: z.array(feedItemSchema),
+  nextCursor: z.string().nullable(),
+  hasMore: z.boolean(),
+});
+
+export type NotificationFeedItem = z.infer<typeof feedItemSchema>;
+type NotificationFeedPage = z.infer<typeof feedPageSchema>;
+
+/** Page-size contract: default 20, server maximum 50. */
+const PAGE_LIMIT = 20;
+
+/** Reopening within this window reuses the cached pages and catches up with a delta instead. */
+const FEED_STALE_TIME_MS = 30_000;
+
+interface FeedQuery {
+  readonly cursor?: string | null;
+  readonly since?: string;
+}
+
+async function fetchNotificationFeed(
+  tier: NotificationTier,
+  query: FeedQuery = {},
+): Promise<NotificationFeedPage> {
+  const searchParams = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+
+  if (query.cursor) searchParams.set("cursor", query.cursor);
+  if (query.since) searchParams.set("since", query.since);
+
+  const page = await apiClient.get(`${tier}/notifications`, { searchParams }).json<unknown>();
+
+  return feedPageSchema.parse(page);
+}
+
+/**
+ * Newest first, one row per id. Cursor pages and `since` deltas both land in the same cached
+ * array, so a row that arrives twice is rendered once.
+ */
+function dedupeById(items: readonly NotificationFeedItem[]): NotificationFeedItem[] {
+  const byId = new Map<number, NotificationFeedItem>();
+
+  for (const item of items) {
+    byId.set(item.id, item);
+  }
+
+  return [...byId.values()].sort(
+    (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt),
+  );
+}
+
+/**
+ * The read path behind the panel. The query only runs while the panel is open; each reopen pulls
+ * the rows created since the newest cached one rather than refetching every page.
+ */
+export function useNotificationFeed(open: boolean) {
+  const tier = useNotificationTier();
+  const queryClient = useQueryClient();
+
+  const feed = useInfiniteQuery({
+    queryKey: notificationKeys.list(null),
+    queryFn: ({ pageParam }) => {
+      if (!tier) throw new Error("Notification tier requires a session");
+      return fetchNotificationFeed(tier, { cursor: pageParam });
+    },
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    enabled: open && tier !== null,
+    staleTime: FEED_STALE_TIME_MS,
+    select: (data) => dedupeById(data.pages.flatMap((page) => page.items)),
+  });
+
+  const newestCreatedAt = feed.data?.[0]?.createdAt;
+
+  useEffect(() => {
+    if (!open || !tier || !newestCreatedAt) return;
+
+    let cancelled = false;
+
+    void fetchNotificationFeed(tier, { since: newestCreatedAt }).then((delta) => {
+      if (cancelled || delta.items.length === 0) return;
+      prependDelta(queryClient, delta.items);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // Keyed on the open transition alone: the delta is a catch-up on reopen, and re-running it
+    // as newestCreatedAt advances would poll the feed behind the panel's back.
+  }, [open]);
+
+  return feed;
+}
+
+function prependDelta(
+  queryClient: ReturnType<typeof useQueryClient>,
+  items: readonly NotificationFeedItem[],
+) {
+  queryClient.setQueryData(
+    notificationKeys.list(null),
+    (current: { pages: NotificationFeedPage[]; pageParams: unknown[] } | undefined) => {
+      if (!current) return current;
+
+      const [head, ...rest] = current.pages;
+
+      return {
+        ...current,
+        pages: [{ ...head, items: dedupeById([...items, ...head.items]) }, ...rest],
+      };
+    },
+  );
+}

--- a/src/features/notification/api/notification-feed.ts
+++ b/src/features/notification/api/notification-feed.ts
@@ -39,9 +39,6 @@ type NotificationFeedPage = z.infer<typeof feedPageSchema>;
 /** Page-size contract: default 20, server maximum 50. */
 const PAGE_LIMIT = 20;
 
-/** Reopening within this window reuses the cached pages and catches up with a delta instead. */
-const FEED_STALE_TIME_MS = 30_000;
-
 interface FeedQuery {
   readonly cursor?: string | null;
   readonly since?: string;
@@ -72,6 +69,8 @@ function dedupeById(items: readonly NotificationFeedItem[]): NotificationFeedIte
     byId.set(item.id, item);
   }
 
+  // Sorting the freshly built array in place; nothing shared is mutated. `.toSorted` would
+  // need an ES2023 lib bump.
   return [...byId.values()].sort(
     (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt),
   );
@@ -94,7 +93,9 @@ export function useNotificationFeed(open: boolean) {
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     enabled: open && tier !== null,
-    staleTime: FEED_STALE_TIME_MS,
+    // Cached pages never go stale on their own; the delta below is what catches them up, so a
+    // reopen does not refetch every page it already holds.
+    staleTime: Number.POSITIVE_INFINITY,
     select: (data) => dedupeById(data.pages.flatMap((page) => page.items)),
   });
 
@@ -105,10 +106,13 @@ export function useNotificationFeed(open: boolean) {
 
     let cancelled = false;
 
-    void fetchNotificationFeed(tier, { since: newestCreatedAt }).then((delta) => {
-      if (cancelled || delta.items.length === 0) return;
-      prependDelta(queryClient, delta.items);
-    });
+    fetchNotificationFeed(tier, { since: newestCreatedAt })
+      .then((delta) => {
+        if (cancelled || delta.items.length === 0) return;
+        prependDelta(queryClient, delta.items);
+      })
+      // A failed catch-up leaves the cached rows standing; the next open tries again.
+      .catch(() => {});
 
     return () => {
       cancelled = true;
@@ -127,7 +131,7 @@ function prependDelta(
   queryClient.setQueryData(
     notificationKeys.list(null),
     (current: { pages: NotificationFeedPage[]; pageParams: unknown[] } | undefined) => {
-      if (!current) return current;
+      if (!current || current.pages.length === 0) return current;
 
       const [head, ...rest] = current.pages;
 

--- a/src/features/notification/api/unread-count.test.ts
+++ b/src/features/notification/api/unread-count.test.ts
@@ -46,8 +46,8 @@ describe("fetchUnreadNotificationCount", () => {
   });
 
   it("reads the platform mount and lets the server cadence header win", async () => {
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      countResponse({ unreadCount: 8 }, { etag: '"pa:2:5"', "x-poll-interval": "10" }),
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () => countResponse({ unreadCount: 8 }, { etag: '"pa:2:5"', "x-poll-interval": "10" }),
     );
     vi.stubGlobal("fetch", fetchMock);
 

--- a/src/features/notification/api/unread-count.ts
+++ b/src/features/notification/api/unread-count.ts
@@ -27,10 +27,7 @@ interface CachedUnreadCount {
 
 const NOT_MODIFIED = 304;
 
-/**
- * Revision ETags are per identity, so each tier keeps its own. Nothing outside this module
- * touches the cache — conditional-request mechanics stay behind `fetchUnreadNotificationCount`.
- */
+/** Revision ETags are per identity, so each tier keeps its own. */
 const cacheByTier = new Map<NotificationTier, CachedUnreadCount>();
 
 function unreadCountPath(tier: NotificationTier) {

--- a/src/features/notification/lib/relative-time.ts
+++ b/src/features/notification/lib/relative-time.ts
@@ -1,0 +1,31 @@
+import type { SupportedLocale } from "@/shared/i18n";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+const formatters: Record<SupportedLocale, Intl.RelativeTimeFormat> = {
+  en: new Intl.RelativeTimeFormat("en", { numeric: "auto", style: "narrow" }),
+  ar: new Intl.RelativeTimeFormat("ar", { numeric: "auto", style: "narrow" }),
+};
+
+const dateFormatters: Record<SupportedLocale, Intl.DateTimeFormat> = {
+  en: new Intl.DateTimeFormat("en-GB", { day: "numeric", month: "short" }),
+  ar: new Intl.DateTimeFormat("ar-SA", { day: "numeric", month: "short" }),
+};
+
+/** Compact age for a feed row: relative up to a week, then a plain short date. */
+export function formatRelativeTime(
+  createdAt: string,
+  locale: SupportedLocale,
+  now: Date = new Date(),
+): string {
+  const created = new Date(createdAt);
+  const elapsed = now.getTime() - created.getTime();
+
+  if (elapsed >= WEEK_MS) return dateFormatters[locale].format(created);
+  if (elapsed >= DAY_MS) return formatters[locale].format(-Math.floor(elapsed / DAY_MS), "day");
+  if (elapsed >= HOUR_MS) return formatters[locale].format(-Math.floor(elapsed / HOUR_MS), "hour");
+  return formatters[locale].format(-Math.floor(elapsed / MINUTE_MS), "minute");
+}

--- a/src/features/notification/model/notification-catalog.ts
+++ b/src/features/notification/model/notification-catalog.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 
 export type NotificationImportance = "high" | "normal";
 
-/** Semantic status colour for the row tile. Importance plays no part in panel presentation. */
+/** Semantic status colour for the row tile. */
 export type NotificationTone = "info" | "success" | "warning";
 
 /** The verified routes a row may navigate to; one member per click-through in the catalog. */
@@ -32,7 +32,7 @@ export interface NotificationSubject {
   readonly publicId: string;
 }
 
-interface NotificationTypeEntry {
+export interface NotificationTypeEntry {
   readonly importance: NotificationImportance;
   readonly tone: NotificationTone;
   readonly icon: LucideIcon;
@@ -63,7 +63,7 @@ export const announcementParamsSchema = z.object({
 
 export const ANNOUNCEMENT_TYPE_KEY = "platform.announcement";
 
-function entry(
+function catalogEntry(
   typeKey: string,
   definition: Omit<NotificationTypeEntry, "copyKey" | "paramsSchema"> &
     Partial<Pick<NotificationTypeEntry, "paramsSchema">>,
@@ -79,26 +79,26 @@ function entry(
 }
 
 export const NOTIFICATION_CATALOG: ReadonlyMap<string, NotificationTypeEntry> = new Map([
-  entry("platform.lead-created", {
+  catalogEntry("platform.lead-created", {
     importance: "normal",
     tone: "info",
     icon: UserPlus,
     route: () => ({ to: "/admin/leads" }),
   }),
-  entry("platform.conversion-requested", {
+  catalogEntry("platform.conversion-requested", {
     importance: "high",
     tone: "warning",
     icon: ArrowRightLeft,
     route: (subject) =>
       subject ? { to: "/admin/conversion-requests/$publicId", publicId: subject.publicId } : null,
   }),
-  entry("platform.company-activated", {
+  catalogEntry("platform.company-activated", {
     importance: "normal",
     tone: "success",
     icon: Building2,
     route: null,
   }),
-  entry("platform.conversion-decided", {
+  catalogEntry("platform.conversion-decided", {
     importance: "normal",
     tone: "info",
     icon: ClipboardCheck,
@@ -106,33 +106,31 @@ export const NOTIFICATION_CATALOG: ReadonlyMap<string, NotificationTypeEntry> = 
     enumParams: ["decision"],
     route: null,
   }),
-  entry(ANNOUNCEMENT_TYPE_KEY, {
+  catalogEntry(ANNOUNCEMENT_TYPE_KEY, {
     importance: "normal",
     tone: "info",
     icon: Megaphone,
     paramsSchema: announcementParamsSchema,
     route: null,
   }),
-  entry("company.subscription-changed", {
+  catalogEntry("company.subscription-changed", {
     importance: "high",
     tone: "warning",
     icon: CreditCard,
     paramsSchema: z.object({ planName: z.string(), status: z.string() }),
     route: () => ({ to: "/company/dashboard" }),
   }),
-  entry("company.role-assigned", {
+  catalogEntry("company.role-assigned", {
     importance: "high",
     tone: "success",
     icon: ShieldCheck,
     paramsSchema: z.object({ roleName: z.string() }),
     route: () => ({ to: "/company/profile" }),
   }),
-  entry("company.user-joined", {
+  catalogEntry("company.user-joined", {
     importance: "normal",
     tone: "success",
     icon: Users,
     route: null,
   }),
 ]);
-
-export type { NotificationTypeEntry };

--- a/src/features/notification/model/notification-catalog.ts
+++ b/src/features/notification/model/notification-catalog.ts
@@ -1,0 +1,138 @@
+import {
+  ArrowRightLeft,
+  Building2,
+  ClipboardCheck,
+  CreditCard,
+  type LucideIcon,
+  Megaphone,
+  ShieldCheck,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { z } from "zod";
+
+/**
+ * Frontend mirror of the backend Notification Type catalog (HRMS_Back_End#198 §2). The backend
+ * ships keys and typed params; everything a row shows — tone, icon, copy, click-through — is
+ * decided here, so no prose ever crosses the wire.
+ */
+
+export type NotificationImportance = "high" | "normal";
+
+/** Semantic status colour for the row tile. Importance plays no part in panel presentation. */
+export type NotificationTone = "info" | "success" | "warning";
+
+/** The verified routes a row may navigate to; one member per click-through in the catalog. */
+export type NotificationRoute =
+  | { readonly to: "/admin/leads" | "/company/dashboard" | "/company/profile" }
+  | { readonly to: "/admin/conversion-requests/$publicId"; readonly publicId: string };
+
+export interface NotificationSubject {
+  readonly type: string;
+  readonly publicId: string;
+}
+
+interface NotificationTypeEntry {
+  readonly importance: NotificationImportance;
+  readonly tone: NotificationTone;
+  readonly icon: LucideIcon;
+  /** Copy key declared by the backend catalog; `.title` and `.body` hang off it. */
+  readonly copyKey: string;
+  readonly paramsSchema: z.ZodType<Record<string, unknown>>;
+  /**
+   * Params holding a closed backend enum. Their values are localized through
+   * `values.<param>.<value>` before interpolation, so Arabic copy never shows an English literal.
+   */
+  readonly enumParams?: readonly string[];
+  /** `null` marks an informational type — the row renders without a navigation affordance. */
+  readonly route: ((subject: NotificationSubject | null) => NotificationRoute | null) | null;
+}
+
+const noParams = z.object({}).passthrough();
+
+const authoredMessageSchema = z.object({ title: z.string(), body: z.string() });
+
+/**
+ * The Announcement carries the Platform Admin's authored prose in its params. The publisher
+ * requires both locales; treating `ar` as optional here is the en fallback the panel promises.
+ */
+export const announcementParamsSchema = z.object({
+  announcementPublicId: z.string().min(1),
+  message: z.object({ en: authoredMessageSchema, ar: authoredMessageSchema.optional() }),
+});
+
+export const ANNOUNCEMENT_TYPE_KEY = "platform.announcement";
+
+function entry(
+  typeKey: string,
+  definition: Omit<NotificationTypeEntry, "copyKey" | "paramsSchema"> &
+    Partial<Pick<NotificationTypeEntry, "paramsSchema">>,
+): [string, NotificationTypeEntry] {
+  return [
+    typeKey,
+    {
+      ...definition,
+      copyKey: `notifications.${typeKey}`,
+      paramsSchema: definition.paramsSchema ?? noParams,
+    },
+  ];
+}
+
+export const NOTIFICATION_CATALOG: ReadonlyMap<string, NotificationTypeEntry> = new Map([
+  entry("platform.lead-created", {
+    importance: "normal",
+    tone: "info",
+    icon: UserPlus,
+    route: () => ({ to: "/admin/leads" }),
+  }),
+  entry("platform.conversion-requested", {
+    importance: "high",
+    tone: "warning",
+    icon: ArrowRightLeft,
+    route: (subject) =>
+      subject ? { to: "/admin/conversion-requests/$publicId", publicId: subject.publicId } : null,
+  }),
+  entry("platform.company-activated", {
+    importance: "normal",
+    tone: "success",
+    icon: Building2,
+    route: null,
+  }),
+  entry("platform.conversion-decided", {
+    importance: "normal",
+    tone: "info",
+    icon: ClipboardCheck,
+    paramsSchema: z.object({ decision: z.enum(["approved", "rejected"]) }),
+    enumParams: ["decision"],
+    route: null,
+  }),
+  entry(ANNOUNCEMENT_TYPE_KEY, {
+    importance: "normal",
+    tone: "info",
+    icon: Megaphone,
+    paramsSchema: announcementParamsSchema,
+    route: null,
+  }),
+  entry("company.subscription-changed", {
+    importance: "high",
+    tone: "warning",
+    icon: CreditCard,
+    paramsSchema: z.object({ planName: z.string(), status: z.string() }),
+    route: () => ({ to: "/company/dashboard" }),
+  }),
+  entry("company.role-assigned", {
+    importance: "high",
+    tone: "success",
+    icon: ShieldCheck,
+    paramsSchema: z.object({ roleName: z.string() }),
+    route: () => ({ to: "/company/profile" }),
+  }),
+  entry("company.user-joined", {
+    importance: "normal",
+    tone: "success",
+    icon: Users,
+    route: null,
+  }),
+]);
+
+export type { NotificationTypeEntry };

--- a/src/features/notification/model/notification-copy.test.ts
+++ b/src/features/notification/model/notification-copy.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import i18next from "i18next";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { SupportedLocale } from "@/shared/i18n";
+import { NOTIFICATION_CATALOG } from "./notification-catalog";
+import { resolveNotificationCopy } from "./notification-copy";
+
+const readCopy = (locale: SupportedLocale) =>
+  JSON.parse(readFileSync(`public/locales/${locale}/notification.json`, "utf8"));
+
+const copyInstance = i18next.createInstance();
+
+/** One sample per v1 catalog type, carrying the params its backend schema declares. */
+const SAMPLE_PARAMS: Record<string, Record<string, unknown>> = {
+  "platform.lead-created": {},
+  "platform.conversion-requested": {},
+  "platform.company-activated": {},
+  "platform.conversion-decided": { decision: "approved" },
+  "platform.announcement": {
+    announcementPublicId: "a-1",
+    message: {
+      en: { title: "Scheduled maintenance", body: "Edara is upgrading on Friday." },
+      ar: { title: "صيانة مجدولة", body: "سيتم تحديث إدارة يوم الجمعة." },
+    },
+  },
+  "company.subscription-changed": { planName: "Growth", status: "active" },
+  "company.role-assigned": { roleName: "Payroll Manager" },
+  "company.user-joined": {},
+};
+
+function copyFor(typeKey: string, locale: SupportedLocale, params = SAMPLE_PARAMS[typeKey]) {
+  return resolveNotificationCopy(
+    { typeKey, params },
+    copyInstance.getFixedT(locale, "notification"),
+    locale,
+  );
+}
+
+describe("resolveNotificationCopy", () => {
+  beforeAll(async () => {
+    await copyInstance.init({
+      lng: "en",
+      fallbackLng: "en",
+      ns: ["notification"],
+      defaultNS: "notification",
+      interpolation: { escapeValue: false },
+      resources: {
+        en: { notification: readCopy("en") },
+        ar: { notification: readCopy("ar") },
+      },
+    });
+  });
+
+  it("renders every v1 catalog type in both locales", () => {
+    for (const typeKey of NOTIFICATION_CATALOG.keys()) {
+      for (const locale of ["en", "ar"] as const) {
+        const copy = copyFor(typeKey, locale);
+
+        expect(copy, `${typeKey} (${locale})`).not.toBeNull();
+        expect(copy?.title, `${typeKey} (${locale}) title`).not.toContain("notifications.");
+        expect(copy?.body, `${typeKey} (${locale}) body`).not.toContain("notifications.");
+      }
+    }
+  });
+
+  it("interpolates typed params", () => {
+    expect(copyFor("company.role-assigned", "en")?.body).toContain("Payroll Manager");
+    expect(copyFor("company.subscription-changed", "en")?.body).toContain("Growth");
+  });
+
+  it("localizes closed enum params instead of interpolating the raw value", () => {
+    expect(copyFor("platform.conversion-decided", "en")?.title).toContain("approved");
+    expect(copyFor("platform.conversion-decided", "ar")?.title).toContain("مقبول");
+  });
+
+  it("takes the announcement's authored prose from params, falling back to en", () => {
+    expect(copyFor("platform.announcement", "ar")?.title).toBe("صيانة مجدولة");
+
+    const englishOnly = {
+      announcementPublicId: "a-2",
+      message: { en: { title: "Only English", body: "No Arabic authored." } },
+    };
+    expect(copyFor("platform.announcement", "ar", englishOnly)?.title).toBe("Only English");
+  });
+
+  it("skips a type key the mirror does not know", () => {
+    expect(copyFor("platform.not-in-catalog", "en", {})).toBeNull();
+  });
+});

--- a/src/features/notification/model/notification-copy.ts
+++ b/src/features/notification/model/notification-copy.ts
@@ -1,0 +1,75 @@
+import type { TFunction } from "i18next";
+import type { SupportedLocale } from "@/shared/i18n";
+import {
+  ANNOUNCEMENT_TYPE_KEY,
+  announcementParamsSchema,
+  NOTIFICATION_CATALOG,
+  type NotificationTypeEntry,
+} from "./notification-catalog";
+
+export interface NotificationCopy {
+  readonly title: string;
+  readonly body: string;
+}
+
+interface CopySource {
+  readonly typeKey: string;
+  readonly params: Record<string, unknown>;
+}
+
+/** `null` when the type key is not in the mirror — an unknown row is skipped, never guessed at. */
+export function resolveNotificationCopy(
+  source: CopySource,
+  t: TFunction,
+  locale: SupportedLocale,
+): NotificationCopy | null {
+  const entry = NOTIFICATION_CATALOG.get(source.typeKey);
+
+  if (!entry) {
+    return null;
+  }
+
+  if (source.typeKey === ANNOUNCEMENT_TYPE_KEY) {
+    const authored = announcementParamsSchema.safeParse(source.params);
+
+    if (authored.success) {
+      const { message } = authored.data;
+      return message[locale] ?? message.en;
+    }
+  }
+
+  const values = localizeEnumParams(entry, readParams(entry, source.params), t);
+
+  return {
+    title: t(`${entry.copyKey}.title`, values),
+    body: t(`${entry.copyKey}.body`, values),
+  };
+}
+
+/** A param shape we cannot read must not take the panel down — the copy renders uninterpolated. */
+function readParams(entry: NotificationTypeEntry, raw: Record<string, unknown>) {
+  const parsed = entry.paramsSchema.safeParse(raw);
+  return parsed.success ? parsed.data : {};
+}
+
+function localizeEnumParams(
+  entry: NotificationTypeEntry,
+  params: Record<string, unknown>,
+  t: TFunction,
+): Record<string, unknown> {
+  if (!entry.enumParams) {
+    return params;
+  }
+
+  const localized: Record<string, unknown> = { ...params };
+
+  for (const name of entry.enumParams) {
+    const value = localized[name];
+
+    if (typeof value === "string") {
+      localized[name] = t(`values.${name}.${value}`, { defaultValue: value });
+    }
+  }
+
+  return localized;
+}

--- a/src/features/notification/model/notification-keys.ts
+++ b/src/features/notification/model/notification-keys.ts
@@ -1,7 +1,4 @@
-/**
- * Query keys locked by the polling contract (HRMS_Back_End#198 §5). The list key is
- * reserved here so the feed slice lands on the same shape the count already uses.
- */
+/** Query keys locked by the polling contract (HRMS_Back_End#198 §5). */
 export const notificationKeys = {
   count: () => ["notifications", "count"] as const,
   list: (cursor: string | null) => ["notifications", "list", cursor] as const,

--- a/src/features/notification/model/poll-cadence.test.ts
+++ b/src/features/notification/model/poll-cadence.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { IDLE_POLL_INTERVAL_MS, resolvePollIntervalMs } from "./poll-cadence";
+
+describe("resolvePollIntervalMs", () => {
+  it("falls back to the idle cadence when the server sends no usable header", () => {
+    expect(resolvePollIntervalMs(null)).toBe(IDLE_POLL_INTERVAL_MS);
+    expect(resolvePollIntervalMs("")).toBe(IDLE_POLL_INTERVAL_MS);
+    expect(resolvePollIntervalMs("0")).toBe(IDLE_POLL_INTERVAL_MS);
+    expect(resolvePollIntervalMs("-30")).toBe(IDLE_POLL_INTERVAL_MS);
+    expect(resolvePollIntervalMs("soon")).toBe(IDLE_POLL_INTERVAL_MS);
+  });
+
+  it("takes the server's cadence whenever it sends one, faster or slower than idle", () => {
+    expect(resolvePollIntervalMs("10")).toBe(10_000);
+    expect(resolvePollIntervalMs("2")).toBe(2_000);
+    expect(resolvePollIntervalMs("120")).toBe(120_000);
+  });
+});

--- a/src/features/notification/model/poll-cadence.ts
+++ b/src/features/notification/model/poll-cadence.ts
@@ -1,9 +1,6 @@
 /** Idle cadence from the polling contract (HRMS_Back_End#198 §5). */
 export const IDLE_POLL_INTERVAL_MS = 30_000;
 
-/** Floor for a server-supplied cadence, so a malformed header cannot turn the badge into a request loop. */
-const MIN_POLL_INTERVAL_MS = 5_000;
-
 /** The server's `x-poll-interval` (seconds) overrides the idle cadence whenever it reads as a usable number. */
 export function resolvePollIntervalMs(serverInterval: string | null): number {
   const seconds = Number(serverInterval);
@@ -12,5 +9,5 @@ export function resolvePollIntervalMs(serverInterval: string | null): number {
     return IDLE_POLL_INTERVAL_MS;
   }
 
-  return Math.max(MIN_POLL_INTERVAL_MS, seconds * 1000);
+  return seconds * 1000;
 }

--- a/src/features/notification/model/recency-bucket.ts
+++ b/src/features/notification/model/recency-bucket.ts
@@ -2,10 +2,11 @@ export const RECENCY_BUCKETS = ["today", "yesterday", "earlier"] as const;
 
 export type RecencyBucket = (typeof RECENCY_BUCKETS)[number];
 
-const startOfDay = (date: Date) =>
-  new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
-
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function startOfDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
 
 /** Calendar-day buckets in the viewer's timezone, so "yesterday" means yesterday to them. */
 export function recencyBucketOf(createdAt: string, now: Date = new Date()): RecencyBucket {

--- a/src/features/notification/model/recency-bucket.ts
+++ b/src/features/notification/model/recency-bucket.ts
@@ -1,0 +1,18 @@
+export const RECENCY_BUCKETS = ["today", "yesterday", "earlier"] as const;
+
+export type RecencyBucket = (typeof RECENCY_BUCKETS)[number];
+
+const startOfDay = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Calendar-day buckets in the viewer's timezone, so "yesterday" means yesterday to them. */
+export function recencyBucketOf(createdAt: string, now: Date = new Date()): RecencyBucket {
+  const today = startOfDay(now);
+  const created = startOfDay(new Date(createdAt));
+
+  if (created >= today) return "today";
+  if (created >= today - DAY_MS) return "yesterday";
+  return "earlier";
+}

--- a/src/features/notification/ui/notification-bell.test.tsx
+++ b/src/features/notification/ui/notification-bell.test.tsx
@@ -1,18 +1,29 @@
+import { readFileSync } from "node:fs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import i18next from "i18next";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthSession, SessionUser } from "@/shared/auth";
 import { useAuthStore } from "@/shared/auth";
 import { NotificationBell } from "./notification-bell";
 
-const unreadCountGetMock = vi.hoisted(() => vi.fn());
+const navigateMock = vi.hoisted(() => vi.fn());
+const apiGetMock = vi.hoisted(() => vi.fn());
 
-// `ky` builds AbortSignals that jsdom's fetch rejects as cross-realm — stub the client
-// boundary instead of the network.
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => navigateMock,
+}));
+
+// `ky` builds AbortSignals that jsdom's fetch rejects as cross-realm — stub the client boundary
+// instead of the network.
 vi.mock("@/shared/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/shared/api")>()),
-  apiClient: { get: unreadCountGetMock },
+  apiClient: { get: apiGetMock },
 }));
+
+const testI18n = i18next.createInstance();
 
 const baseUser: SessionUser = {
   publicId: "user-1",
@@ -36,25 +47,78 @@ const session: AuthSession = {
   user: baseUser,
 };
 
-function renderBell(unreadCount: number) {
-  unreadCountGetMock.mockResolvedValue(
-    new Response(JSON.stringify({ unreadCount }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    }),
-  );
-  useAuthStore.setState({ session, status: "authenticated" });
+const now = new Date();
+const hoursAgo = (hours: number) => new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
 
+const leadRow = {
+  id: 1,
+  scope: "platform",
+  typeKey: "platform.lead-created",
+  typeVersion: 1,
+  importance: "normal",
+  params: {},
+  actor: { kind: "system" },
+  subject: { type: "lead", publicId: "lead-1" },
+  createdAt: hoursAgo(1),
+  seenAt: null,
+  readAt: null,
+};
+
+const informationalRow = {
+  ...leadRow,
+  id: 2,
+  typeKey: "company.user-joined",
+  subject: null,
+  createdAt: hoursAgo(30),
+};
+
+function stubEndpoints({ unreadCount = 0, items = [] as unknown[] } = {}) {
+  apiGetMock.mockImplementation((path: string) => {
+    if (path.endsWith("unread-count")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ unreadCount }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+
+    return { json: async () => ({ items, nextCursor: null, hasMore: false }) };
+  });
+}
+
+function renderBell() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
   return render(
-    <QueryClientProvider client={queryClient}>
-      <NotificationBell />
-    </QueryClientProvider>,
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>
+        <NotificationBell />
+      </QueryClientProvider>
+    </I18nextProvider>,
   );
 }
 
 describe("NotificationBell", () => {
+  beforeAll(async () => {
+    await testI18n.init({
+      lng: "en",
+      fallbackLng: "en",
+      ns: ["notification"],
+      defaultNS: "notification",
+      interpolation: { escapeValue: false },
+      resources: {
+        en: {
+          notification: JSON.parse(readFileSync("public/locales/en/notification.json", "utf8")),
+        },
+      },
+    });
+  });
+
+  beforeEach(() => {
+    useAuthStore.setState({ session, status: "authenticated" });
+  });
+
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
@@ -62,16 +126,60 @@ describe("NotificationBell", () => {
   });
 
   it("caps the badge at 99+ and announces the count on the bell", async () => {
-    renderBell(128);
+    stubEndpoints({ unreadCount: 128 });
+    renderBell();
 
     expect(await screen.findByText("99+")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Notifications, 128 unread" })).toBeInTheDocument();
   });
 
   it("hides the badge while nothing is unread", async () => {
-    renderBell(0);
+    stubEndpoints();
+    renderBell();
 
     expect(await screen.findByRole("button", { name: "Notifications" })).toBeInTheDocument();
     expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("opens the panel on the bell, groups rows by recency, and closes on Escape", async () => {
+    stubEndpoints({ items: [leadRow, informationalRow] });
+    renderBell();
+
+    const bell = await screen.findByRole("button", { name: "Notifications" });
+    expect(bell).toHaveAttribute("aria-haspopup", "dialog");
+    expect(bell).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(bell);
+    expect(bell).toHaveAttribute("aria-expanded", "true");
+
+    expect(await screen.findByText("New lead registered")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Yesterday" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(bell).toHaveAttribute("aria-expanded", "false"));
+    expect(bell).toHaveFocus();
+  });
+
+  it("navigates from a clickable row and leaves informational rows without an affordance", async () => {
+    stubEndpoints({ items: [leadRow, informationalRow] });
+    renderBell();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Notifications" }));
+    fireEvent.click(await screen.findByRole("button", { name: /New lead registered/ }));
+
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/admin/leads" });
+    expect(screen.queryByRole("button", { name: /New member joined/ })).not.toBeInTheDocument();
+    expect(screen.getByText("New member joined")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the feed has no rows", async () => {
+    stubEndpoints();
+    renderBell();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Notifications" }));
+
+    expect(await screen.findByText("You're all caught up")).toBeInTheDocument();
   });
 });

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -1,19 +1,66 @@
 import { Bell } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/shared/ui/button";
 import { useUnreadNotificationCount } from "../api/unread-count";
+import { NotificationPanel } from "./notification-panel";
 
 const BADGE_COUNT_CAP = 99;
 
 export function NotificationBell() {
+  const { t } = useTranslation("notification");
   const { data } = useUnreadNotificationCount();
+  const [open, setOpen] = useState(false);
+  const bellRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+
   const unreadCount = data?.unreadCount ?? 0;
+
+  useEffect(() => {
+    if (!open) return;
+
+    panelRef.current?.focus();
+
+    function closeAndRestoreFocus() {
+      setOpen(false);
+      bellRef.current?.focus();
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") closeAndRestoreFocus();
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      const target = event.target as Node;
+      if (panelRef.current?.contains(target) || bellRef.current?.contains(target)) return;
+      setOpen(false);
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [open]);
 
   return (
     <div className="relative">
       <Button
+        ref={bellRef}
         intent="toggle"
         size="iconSm"
-        aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : "Notifications"}
+        aria-label={
+          unreadCount > 0
+            ? `${t("panel.title")}, ${t("panel.unread", { count: unreadCount })}`
+            : t("panel.title")
+        }
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((previous) => !previous)}
         leadingIcon={<Bell size={16} />}
         iconOnly
       />
@@ -25,6 +72,13 @@ export function NotificationBell() {
           {formatBadgeCount(unreadCount)}
         </span>
       )}
+
+      <NotificationPanel
+        open={open}
+        panelId={panelId}
+        panelRef={panelRef}
+        onClose={() => setOpen(false)}
+      />
     </div>
   );
 }

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -7,8 +7,10 @@ import { NotificationPanel } from "./notification-panel";
 
 const BADGE_COUNT_CAP = 99;
 
+const FOCUSABLE_SELECTOR = 'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])';
+
 export function NotificationBell() {
-  const { t } = useTranslation("notification");
+  const { t } = useTranslation("notification", { useSuspense: false });
   const { data } = useUnreadNotificationCount();
   const [open, setOpen] = useState(false);
   const bellRef = useRef<HTMLButtonElement>(null);
@@ -16,24 +18,30 @@ export function NotificationBell() {
   const panelId = useId();
 
   const unreadCount = data?.unreadCount ?? 0;
+  const label = t("panel.title");
 
   useEffect(() => {
     if (!open) return;
 
     panelRef.current?.focus();
 
-    function closeAndRestoreFocus() {
-      setOpen(false);
-      bellRef.current?.focus();
-    }
-
     function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") closeAndRestoreFocus();
+      if (event.key === "Escape") {
+        setOpen(false);
+        bellRef.current?.focus();
+        return;
+      }
+
+      if (event.key === "Tab") keepFocusInPanel(event, panelRef.current);
     }
 
+    // Focus stays where the click landed; only Escape hands it back to the bell.
     function onPointerDown(event: PointerEvent) {
-      const target = event.target as Node;
+      const target = event.target;
+
+      if (!(target instanceof Node)) return;
       if (panelRef.current?.contains(target) || bellRef.current?.contains(target)) return;
+
       setOpen(false);
     }
 
@@ -52,10 +60,9 @@ export function NotificationBell() {
         ref={bellRef}
         intent="toggle"
         size="iconSm"
+        title={label}
         aria-label={
-          unreadCount > 0
-            ? `${t("panel.title")}, ${t("panel.unread", { count: unreadCount })}`
-            : t("panel.title")
+          unreadCount > 0 ? `${label}, ${t("panel.unread", { count: unreadCount })}` : label
         }
         aria-haspopup="dialog"
         aria-expanded={open}
@@ -64,14 +71,14 @@ export function NotificationBell() {
         leadingIcon={<Bell size={16} />}
         iconOnly
       />
-      {unreadCount > 0 && (
+      {unreadCount > 0 ? (
         <span
           aria-hidden="true"
           className="pointer-events-none absolute -top-1 -end-1 inline-flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-sm)] bg-[var(--color-primary)] px-1 text-[10px] font-semibold leading-none tabular-nums text-[var(--color-on-primary)] ring-2 ring-[var(--color-bg)]"
         >
           {formatBadgeCount(unreadCount)}
         </span>
-      )}
+      ) : null}
 
       <NotificationPanel
         open={open}
@@ -81,6 +88,30 @@ export function NotificationBell() {
       />
     </div>
   );
+}
+
+/** Tab cycles inside the open dialog instead of walking off into the page behind it. */
+function keepFocusInPanel(event: KeyboardEvent, panel: HTMLDivElement | null) {
+  if (!panel) return;
+
+  const focusable = [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+
+  if (focusable.length === 0) {
+    event.preventDefault();
+    panel.focus();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const atEdge = event.shiftKey
+    ? document.activeElement === first
+    : document.activeElement === last;
+
+  if (!atEdge) return;
+
+  event.preventDefault();
+  (event.shiftKey ? last : first).focus();
 }
 
 function formatBadgeCount(count: number) {

--- a/src/features/notification/ui/notification-panel.tsx
+++ b/src/features/notification/ui/notification-panel.tsx
@@ -1,0 +1,133 @@
+import { BellOff } from "lucide-react";
+import type { RefObject } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import type { NotificationFeedItem } from "../api/notification-feed";
+import { useNotificationFeed } from "../api/notification-feed";
+import { NOTIFICATION_CATALOG } from "../model/notification-catalog";
+import { RECENCY_BUCKETS, type RecencyBucket, recencyBucketOf } from "../model/recency-bucket";
+import { NotificationRow } from "./notification-row";
+
+interface NotificationPanelProps {
+  open: boolean;
+  panelId: string;
+  panelRef: RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+}
+
+export function NotificationPanel({ open, panelId, panelRef, onClose }: NotificationPanelProps) {
+  const { t } = useTranslation("notification");
+  const { data, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useNotificationFeed(open);
+
+  // A type the mirror does not know cannot be rendered, and must not leave an empty bucket behind.
+  const items = (data ?? []).filter((item) => NOTIFICATION_CATALOG.has(item.typeKey));
+
+  return (
+    <div
+      ref={panelRef}
+      id={panelId}
+      role="dialog"
+      aria-label={t("panel.title")}
+      tabIndex={-1}
+      inert={!open}
+      aria-hidden={!open}
+      className={cn(
+        "absolute top-[calc(100%+8px)] end-0 z-40 flex max-h-[min(560px,calc(100dvh-88px))] w-[384px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-md)] outline-none",
+        // Scales out of the bell it hangs from, and leaves faster than it arrives.
+        "origin-top transition-[transform,opacity,visibility] ease-[var(--motion-easing)] ltr:origin-top-right rtl:origin-top-left",
+        open
+          ? "visible translate-y-0 scale-100 opacity-100 duration-[var(--motion-base)]"
+          : "pointer-events-none invisible -translate-y-1 scale-[0.98] opacity-0 duration-[var(--motion-fast)]",
+      )}
+    >
+      <header className="flex shrink-0 items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
+        <h2 className="text-sm font-semibold tracking-tight text-[var(--color-text)]">
+          {t("panel.title")}
+        </h2>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {isPending && <PanelMessage>{t("panel.loading")}</PanelMessage>}
+        {isError && <PanelMessage>{t("panel.error")}</PanelMessage>}
+        {!isPending && !isError && items.length === 0 && (
+          <EmptyFeed title={t("panel.empty.title")} hint={t("panel.empty.hint")} />
+        )}
+
+        {RECENCY_BUCKETS.map((bucket) => (
+          <BucketSection
+            key={bucket}
+            bucket={bucket}
+            label={t(`panel.buckets.${bucket}`)}
+            items={items.filter((item) => recencyBucketOf(item.createdAt) === bucket)}
+            onNavigate={onClose}
+          />
+        ))}
+      </div>
+
+      {hasNextPage && (
+        <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
+          <Button
+            variant="ghost"
+            size="block"
+            isLoading={isFetchingNextPage}
+            onClick={() => void fetchNextPage()}
+          >
+            {t("panel.showOlder")}
+          </Button>
+        </footer>
+      )}
+    </div>
+  );
+}
+
+interface BucketSectionProps {
+  bucket: RecencyBucket;
+  label: string;
+  items: NotificationFeedItem[];
+  onNavigate: () => void;
+}
+
+function BucketSection({ bucket, label, items, onNavigate }: BucketSectionProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby={`notification-bucket-${bucket}`}>
+      <h3
+        id={`notification-bucket-${bucket}`}
+        className="sticky top-0 bg-[var(--color-surface)] px-4 pb-1 pt-3 text-[11px] font-semibold uppercase tracking-widest text-[var(--color-text-faint)]"
+      >
+        {label}
+      </h3>
+      <ul>
+        {items.map((item) => (
+          <NotificationRow key={item.id} item={item} onNavigate={onNavigate} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function PanelMessage({ children }: { children: string }) {
+  return (
+    <p className="px-4 py-8 text-center text-[13px] text-[var(--color-text-muted)]">{children}</p>
+  );
+}
+
+function EmptyFeed({ title, hint }: { title: string; hint: string }) {
+  return (
+    <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
+      <span
+        aria-hidden="true"
+        className="flex size-9 items-center justify-center rounded-full bg-[var(--color-surface-2)] text-[var(--color-text-faint)]"
+      >
+        <BellOff size={16} />
+      </span>
+      <p className="text-[13px] font-medium text-[var(--color-text)]">{title}</p>
+      <p className="max-w-[240px] text-xs leading-relaxed text-[var(--color-text-faint)]">{hint}</p>
+    </div>
+  );
+}

--- a/src/features/notification/ui/notification-panel.tsx
+++ b/src/features/notification/ui/notification-panel.tsx
@@ -17,7 +17,7 @@ interface NotificationPanelProps {
 }
 
 export function NotificationPanel({ open, panelId, panelRef, onClose }: NotificationPanelProps) {
-  const { t } = useTranslation("notification");
+  const { t } = useTranslation("notification", { useSuspense: false });
   const { data, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
     useNotificationFeed(open);
 
@@ -35,7 +35,7 @@ export function NotificationPanel({ open, panelId, panelRef, onClose }: Notifica
       aria-hidden={!open}
       className={cn(
         "absolute top-[calc(100%+8px)] end-0 z-40 flex max-h-[min(560px,calc(100dvh-88px))] w-[384px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-md)] outline-none",
-        // Scales out of the bell it hangs from, and leaves faster than it arrives.
+        // Scales out of the bell it hangs from; exit is shorter than entry.
         "origin-top transition-[transform,opacity,visibility] ease-[var(--motion-easing)] ltr:origin-top-right rtl:origin-top-left",
         open
           ? "visible translate-y-0 scale-100 opacity-100 duration-[var(--motion-base)]"
@@ -49,11 +49,11 @@ export function NotificationPanel({ open, panelId, panelRef, onClose }: Notifica
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {isPending && <PanelMessage>{t("panel.loading")}</PanelMessage>}
-        {isError && <PanelMessage>{t("panel.error")}</PanelMessage>}
-        {!isPending && !isError && items.length === 0 && (
+        {isPending ? <PanelMessage>{t("panel.loading")}</PanelMessage> : null}
+        {isError ? <PanelMessage>{t("panel.error")}</PanelMessage> : null}
+        {!isPending && !isError && items.length === 0 ? (
           <EmptyFeed title={t("panel.empty.title")} hint={t("panel.empty.hint")} />
-        )}
+        ) : null}
 
         {RECENCY_BUCKETS.map((bucket) => (
           <BucketSection
@@ -66,7 +66,7 @@ export function NotificationPanel({ open, panelId, panelRef, onClose }: Notifica
         ))}
       </div>
 
-      {hasNextPage && (
+      {hasNextPage ? (
         <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
           <Button
             variant="ghost"
@@ -77,7 +77,7 @@ export function NotificationPanel({ open, panelId, panelRef, onClose }: Notifica
             {t("panel.showOlder")}
           </Button>
         </footer>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -111,13 +111,22 @@ function BucketSection({ bucket, label, items, onNavigate }: BucketSectionProps)
   );
 }
 
-function PanelMessage({ children }: { children: string }) {
+interface PanelMessageProps {
+  children: string;
+}
+
+function PanelMessage({ children }: PanelMessageProps) {
   return (
     <p className="px-4 py-8 text-center text-[13px] text-[var(--color-text-muted)]">{children}</p>
   );
 }
 
-function EmptyFeed({ title, hint }: { title: string; hint: string }) {
+interface EmptyFeedProps {
+  title: string;
+  hint: string;
+}
+
+function EmptyFeed({ title, hint }: EmptyFeedProps) {
   return (
     <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
       <span

--- a/src/features/notification/ui/notification-row.tsx
+++ b/src/features/notification/ui/notification-row.tsx
@@ -1,0 +1,111 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { usePreferencesStore } from "@/shared/config";
+import { cn } from "@/shared/lib/cn";
+import type { NotificationFeedItem } from "../api/notification-feed";
+import { formatRelativeTime } from "../lib/relative-time";
+import {
+  NOTIFICATION_CATALOG,
+  type NotificationRoute,
+  type NotificationTone,
+} from "../model/notification-catalog";
+import { resolveNotificationCopy } from "../model/notification-copy";
+
+const toneClassName: Record<NotificationTone, string> = {
+  info: "bg-[var(--color-info-soft)] text-[var(--color-info)]",
+  success: "bg-[var(--color-success-soft)] text-[var(--color-success)]",
+  warning: "bg-[var(--color-warning-soft)] text-[var(--color-warning)]",
+};
+
+const rowClassName = "flex w-full items-start gap-2.5 px-4 py-2.5 text-start";
+
+const unseenRowClassName =
+  "bg-[color-mix(in_srgb,var(--color-primary-soft)_55%,var(--color-surface))]";
+
+interface NotificationRowProps {
+  item: NotificationFeedItem;
+  /** Closes the panel once a clickable row has navigated. */
+  onNavigate: () => void;
+}
+
+export function NotificationRow({ item, onNavigate }: NotificationRowProps) {
+  const { t } = useTranslation("notification");
+  const locale = usePreferencesStore((state) => state.locale);
+  const navigate = useNavigate();
+
+  const entry = NOTIFICATION_CATALOG.get(item.typeKey);
+  const copy = resolveNotificationCopy(item, t, locale);
+
+  if (!entry || !copy) {
+    return null;
+  }
+
+  const route = entry.route?.(item.subject) ?? null;
+  const Icon = entry.icon;
+  const unseen = item.seenAt === null;
+
+  const content = (
+    <>
+      {unseen && (
+        <span
+          aria-hidden="true"
+          className="mt-1.5 size-1.5 shrink-0 rounded-full bg-[var(--color-primary)]"
+        />
+      )}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-md)]",
+          toneClassName[entry.tone],
+        )}
+      >
+        <Icon size={14} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13px] font-medium leading-snug text-[var(--color-text)]">
+          {copy.title}
+        </span>
+        <span className="mt-0.5 block truncate text-xs leading-snug text-[var(--color-text-muted)]">
+          {copy.body}
+        </span>
+      </span>
+      <time
+        dateTime={item.createdAt}
+        className="shrink-0 pt-0.5 text-[11px] tabular-nums text-[var(--color-text-faint)]"
+      >
+        {formatRelativeTime(item.createdAt, locale)}
+      </time>
+    </>
+  );
+
+  if (!route) {
+    return <li className={cn(rowClassName, unseen && unseenRowClassName)}>{content}</li>;
+  }
+
+  return (
+    <li className={cn(unseen && unseenRowClassName)}>
+      <button
+        type="button"
+        onClick={() => {
+          navigateTo(navigate, route);
+          onNavigate();
+        }}
+        className={cn(
+          rowClassName,
+          "cursor-pointer transition-colors duration-[var(--motion-fast)] ease-[var(--motion-easing)] hover:bg-[var(--color-surface-2)] focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--color-primary)]",
+        )}
+      >
+        {content}
+      </button>
+    </li>
+  );
+}
+
+function navigateTo(navigate: ReturnType<typeof useNavigate>, route: NotificationRoute) {
+  if (route.to === "/admin/conversion-requests/$publicId") {
+    void navigate({ to: route.to, params: { publicId: route.publicId } });
+    return;
+  }
+
+  void navigate({ to: route.to });
+}

--- a/src/features/notification/ui/notification-row.tsx
+++ b/src/features/notification/ui/notification-row.tsx
@@ -29,7 +29,7 @@ interface NotificationRowProps {
 }
 
 export function NotificationRow({ item, onNavigate }: NotificationRowProps) {
-  const { t } = useTranslation("notification");
+  const { t } = useTranslation("notification", { useSuspense: false });
   const locale = usePreferencesStore((state) => state.locale);
   const navigate = useNavigate();
 
@@ -46,12 +46,12 @@ export function NotificationRow({ item, onNavigate }: NotificationRowProps) {
 
   const content = (
     <>
-      {unseen && (
+      {unseen ? (
         <span
           aria-hidden="true"
           className="mt-1.5 size-1.5 shrink-0 rounded-full bg-[var(--color-primary)]"
         />
-      )}
+      ) : null}
       <span
         aria-hidden="true"
         className={cn(

--- a/src/shared/i18n/config.ts
+++ b/src/shared/i18n/config.ts
@@ -24,9 +24,6 @@ void i18next
     },
     saveMissing: import.meta.env.DEV,
     returnNull: false,
-    // No Suspense boundary wraps the app shell, so a namespace that is still loading must
-    // fall through to the key rather than suspend the header out of the page.
-    react: { useSuspense: false },
   });
 
 export { i18next };

--- a/src/shared/i18n/config.ts
+++ b/src/shared/i18n/config.ts
@@ -15,7 +15,7 @@ void i18next
     fallbackLng: defaultLocale,
     supportedLngs: supportedLocales,
     defaultNS: "common",
-    ns: ["common", "auth"],
+    ns: ["common", "auth", "notification"],
     interpolation: {
       escapeValue: false,
     },
@@ -24,6 +24,9 @@ void i18next
     },
     saveMissing: import.meta.env.DEV,
     returnNull: false,
+    // No Suspense boundary wraps the app shell, so a namespace that is still loading must
+    // fall through to the key rather than suspend the header out of the page.
+    react: { useSuspense: false },
   });
 
 export { i18next };

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode } from "react";
+import type { ButtonHTMLAttributes, ReactNode, Ref } from "react";
 import { cn } from "@/shared/lib/cn";
 
 type ButtonVariant = "primary" | "secondary" | "ghost" | "destructive" | "subtle" | "link" | "nav";
@@ -60,6 +60,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconOnly?: boolean;
   /** Controlled pressed state for toggle (sets aria-pressed + pressed styling) */
   pressed?: boolean;
+  ref?: Ref<HTMLButtonElement>;
 }
 
 const variantClassName: Record<ButtonVariant, string> = {

--- a/steiger.config.js
+++ b/steiger.config.js
@@ -138,9 +138,9 @@ export default defineConfig([
     },
   },
   {
-    // The notification center is deliberately one slice both portals' shells mount
-    // (HRMS-UI#53). The app-shell widget being its only consumer is the point, not a
-    // smell — merging it there would bury portal-agnostic notification logic in a layout block.
+    // Documented exemption to docs/frontend-architecture.md §3: the notification center is one
+    // slice both portals' shells mount (HRMS-UI#53), so app-shell is its only consumer by design.
+    // Merging it there would bury portal-agnostic notification logic in a layout widget.
     files: ["./src/features/notification/**"],
     rules: {
       "fsd/insignificant-slice": "off",


### PR DESCRIPTION
Closes Edara-Solutions/HRMS-UI#55.

Opening the bell opens the locked Variant A dropdown rendering the real feed read-only — the full path from list endpoint to rendered rows.

## What's in it

| File | Role |
| --- | --- |
| `model/notification-catalog.ts` | Mirror of all eight v1 types — importance, tone, icon, copy key, params schema, route builder |
| `model/notification-copy.ts` | Copy resolution: typed param interpolation, closed-enum localization, announcement prose from params |
| `model/recency-bucket.ts` | Today / Yesterday / Earlier in the viewer's timezone |
| `api/notification-feed.ts` | Interim `NotificationFeedPage` contract, `limit=20` cursor paging, `since`-delta merge, dedupe by id |
| `ui/notification-panel.tsx` | Variant A dropdown — bucket sections, empty state, "Show older" |
| `ui/notification-row.tsx` | Tone tile, unseen wash, clickable vs informational rows |
| `ui/notification-bell.tsx` | Trigger owning open state, Esc + focus return, focus trap, outside-click |
| `public/locales/{en,ar}/notification.json` | Panel chrome plus all eight types' copy |

## Contract

Pinned to the shapes the backend already implements on `feature/notification` (`notification-feed.routes.ts`, per HRMS_Back_End#198 §5): `GET {tier}/notifications?since&limit&cursor` → `{ items, nextCursor, hasMore }`. The backend isn't reachable, so wire types stay a marked interim Zod contract for swap with `bun run openapi:types`.

## Review pass

A two-axis review (standards + spec) ran against `496ee18...HEAD`, covering #54 and #55. Fixes folded in as `6413d3d`:

- Focus trap on the panel dialog; Escape returns focus to the bell, outside-click leaves it where the user clicked
- `title` alongside `aria-label` on the icon-only bell
- The server's `x-poll-interval` now wins outright — a 5s client floor was silently overriding it, which the #54 contract does not allow
- The `since` delta catches its own rejections, and cached pages no longer double-refetch on reopen (`staleTime: Infinity`, delta owns catch-up)
- `useSuspense: false` scoped to this slice's `useTranslation` calls instead of the app-wide i18next config
- Ternaries over `&&` in JSX, prop interfaces, guarded delta merge, trimmed narrative comments

One review finding was rejected: "your company is now active" was flagged as the wrong voice for platform-scoped types, but the backend epic's audience table delivers `platform.company-activated` to "That Company's Owner (cross-tier)" and `platform.conversion-decided` to the "Requesting Company's Owner" — the second-person voice is correct.

## Known gaps, deliberately out of scope

- The epic's 10s panel-open poll cadence is in #53 but in neither issue's AC.
- The badge reads `unreadCount`; #54's AC says "unseen". The endpoint exposes only the former.
- `platform.announcement` renders informational — the epic calls it "target-aware", but no announcement route exists in the UI yet.

## Verification

`typecheck`, `lint` (Biome + Steiger), and 186 tests green — 15 covering this slice: every catalog type in en+ar, cursor paging and delta dedupe, cadence resolution, and the panel's open/Escape/navigate/empty paths.
