### PR TITLE
Notification center: production toaster (stack, durations, motion, live region)

### DIFF
--- a/public/locales/ar/notification.json
+++ b/public/locales/ar/notification.json
@@ -17,6 +17,11 @@
     "error": "تعذّر تحميل الإشعارات.",
     "actionError": "لم تتم العملية. حاول مجدداً."
   },
+  "toast": {
+    "region": "أحدث الإشعارات",
+    "dismiss": "إغلاق الإشعار",
+    "earlier": "+{{count}} سابق"
+  },
   "values": {
     "decision": {
       "approved": "مقبول",

--- a/public/locales/en/notification.json
+++ b/public/locales/en/notification.json
@@ -17,6 +17,11 @@
     "error": "Notifications could not be loaded.",
     "actionError": "That didn't go through. Try again."
   },
+  "toast": {
+    "region": "Recent notifications",
+    "dismiss": "Dismiss notification",
+    "earlier": "+{{count}} earlier"
+  },
   "values": {
     "decision": {
       "approved": "approved",

--- a/src/features/notification/index.ts
+++ b/src/features/notification/index.ts
@@ -1,1 +1,2 @@
 export { NotificationBell } from "./ui/notification-bell";
+export { NotificationToaster } from "./ui/notification-toaster";

--- a/src/features/notification/lib/use-auto-dismiss.ts
+++ b/src/features/notification/lib/use-auto-dismiss.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Runs `onExpire` once the toast has been on screen for `durationMs`, pausing whenever the pointer
+ * rests on the stack. The remaining time is carried across pauses, so hovering a toast at 4.9s and
+ * leaving again still gives it the last 100ms rather than a fresh clock.
+ *
+ * @param durationMs `null` for a sticky toast — it never expires on its own.
+ */
+export function useAutoDismiss(durationMs: number | null, paused: boolean, onExpire: () => void) {
+  const remainingMs = useRef(durationMs);
+  const expire = useRef(onExpire);
+
+  useEffect(() => {
+    expire.current = onExpire;
+  });
+
+  useEffect(() => {
+    if (remainingMs.current === null || paused) {
+      return;
+    }
+
+    const startedAt = Date.now();
+    const timer = setTimeout(() => expire.current(), remainingMs.current);
+
+    return () => {
+      clearTimeout(timer);
+      remainingMs.current = Math.max(0, (remainingMs.current ?? 0) - (Date.now() - startedAt));
+    };
+  }, [paused]);
+}

--- a/src/features/notification/model/toast-store.ts
+++ b/src/features/notification/model/toast-store.ts
@@ -1,0 +1,87 @@
+import { create } from "zustand";
+import { NOTIFICATION_CATALOG, type NotificationTone } from "./notification-catalog";
+
+/**
+ * Toast tones extend the catalog's set with `danger`, the one tone that never auto-dismisses.
+ * No catalog type carries it — a sticky toast asks for it explicitly.
+ */
+export type ToastTone = NotificationTone | "danger";
+
+/** How long a tone stays on screen; `null` keeps the toast until someone dismisses it. */
+export const TOAST_DURATION_MS: Record<ToastTone, number | null> = {
+  info: 5_000,
+  success: 5_000,
+  warning: 7_000,
+  danger: null,
+};
+
+/** Beyond this the stack stops growing and older toasts collapse into the "+N earlier" pill. */
+export const MAX_VISIBLE_TOASTS = 3;
+
+export interface ToastRequest {
+  readonly typeKey: string;
+  readonly params?: Record<string, unknown>;
+  /** Overrides the tone the catalog gives the type. */
+  readonly tone?: ToastTone;
+}
+
+export interface NotificationToast {
+  readonly id: number;
+  readonly typeKey: string;
+  readonly params: Record<string, unknown>;
+  readonly tone: ToastTone;
+}
+
+interface ToastState {
+  toasts: readonly NotificationToast[];
+  /** Toasts pushed out of the visible stack and still counted by the pill. */
+  earlierCount: number;
+  showToast: (request: ToastRequest) => void;
+  dismissToast: (id: number) => void;
+}
+
+let lastToastId = 0;
+
+/**
+ * The toaster's whole state. Dismissal is presentation-only — nothing here talks to the server,
+ * and a dismissed toast leaves its notification unread.
+ */
+export const useToastStore = create<ToastState>()((set) => ({
+  toasts: [],
+  earlierCount: 0,
+
+  showToast: (request) =>
+    set((state) => {
+      const entry = NOTIFICATION_CATALOG.get(request.typeKey);
+
+      // A type the mirror does not know has no copy, tone or icon to render.
+      if (!entry) {
+        return state;
+      }
+
+      lastToastId += 1;
+
+      const stack = [
+        ...state.toasts,
+        {
+          id: lastToastId,
+          typeKey: request.typeKey,
+          params: request.params ?? {},
+          tone: request.tone ?? entry.tone,
+        },
+      ];
+
+      return {
+        toasts: stack.slice(-MAX_VISIBLE_TOASTS),
+        earlierCount: state.earlierCount + Math.max(0, stack.length - MAX_VISIBLE_TOASTS),
+      };
+    }),
+
+  dismissToast: (id) =>
+    set((state) => {
+      const toasts = state.toasts.filter((toast) => toast.id !== id);
+
+      // An empty stack has nothing left to be "earlier" than.
+      return { toasts, earlierCount: toasts.length === 0 ? 0 : state.earlierCount };
+    }),
+}));

--- a/src/features/notification/ui/notification-toast.tsx
+++ b/src/features/notification/ui/notification-toast.tsx
@@ -1,0 +1,106 @@
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { usePreferencesStore } from "@/shared/config";
+import { cn } from "@/shared/lib/cn";
+import { useAutoDismiss } from "../lib/use-auto-dismiss";
+import { NOTIFICATION_CATALOG } from "../model/notification-catalog";
+import { resolveNotificationCopy } from "../model/notification-copy";
+import {
+  type NotificationToast,
+  TOAST_DURATION_MS,
+  type ToastTone,
+  useToastStore,
+} from "../model/toast-store";
+
+const EXIT_DURATION_MS = 120;
+
+/** Enter 180ms, exit 120ms, transform and opacity only — the reduced-motion block collapses both. */
+const motionClassName = {
+  entering: "translate-y-2 opacity-0 duration-[var(--motion-base)]",
+  visible: "translate-y-0 opacity-100 duration-[var(--motion-base)]",
+  leaving: "translate-y-1 opacity-0 duration-[var(--motion-fast)]",
+};
+
+const toneClassName: Record<ToastTone, string> = {
+  info: "bg-[var(--color-info-soft)] text-[var(--color-info)]",
+  success: "bg-[var(--color-success-soft)] text-[var(--color-success)]",
+  warning: "bg-[var(--color-warning-soft)] text-[var(--color-warning)]",
+  danger: "bg-[var(--color-danger-soft)] text-[var(--color-danger)]",
+};
+
+interface NotificationToastCardProps {
+  toast: NotificationToast;
+  /** True while the pointer rests on the stack; the auto-dismiss clock waits it out. */
+  paused: boolean;
+}
+
+export function NotificationToastCard({ toast, paused }: NotificationToastCardProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+  const locale = usePreferencesStore((preferences) => preferences.locale);
+  const dismissToast = useToastStore((state) => state.dismissToast);
+  const [entered, setEntered] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  // The card animates itself out before it leaves the stack, so the store never holds exit state.
+  useEffect(() => {
+    if (!leaving) return;
+
+    const timer = setTimeout(() => dismissToast(toast.id), EXIT_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [leaving, dismissToast, toast.id]);
+
+  useAutoDismiss(TOAST_DURATION_MS[toast.tone], paused, () => setLeaving(true));
+
+  const entry = NOTIFICATION_CATALOG.get(toast.typeKey);
+  const copy = resolveNotificationCopy(toast, t, locale);
+
+  if (!entry || !copy) {
+    return null;
+  }
+
+  const Icon = entry.icon;
+  const motion = leaving ? "leaving" : entered ? "visible" : "entering";
+
+  return (
+    <li
+      className={cn(
+        "flex items-start gap-2.5 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] p-3 shadow-[var(--shadow-md)]",
+        "transition-[transform,opacity] ease-[var(--motion-easing)]",
+        motionClassName[motion],
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-md)]",
+          toneClassName[toast.tone],
+        )}
+      >
+        <Icon size={14} />
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-[13px] font-medium leading-snug text-[var(--color-text)]">
+          {copy.title}
+        </p>
+        <p className="mt-0.5 text-xs leading-snug text-[var(--color-text-muted)]">{copy.body}</p>
+      </div>
+
+      <button
+        type="button"
+        title={t("toast.dismiss")}
+        aria-label={t("toast.dismiss")}
+        onClick={() => setLeaving(true)}
+        className="-me-1 -mt-1 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-[var(--radius-md)] text-[var(--color-text-faint)] transition-colors duration-[var(--motion-fast)] ease-[var(--motion-easing)] hover:bg-[var(--color-surface-2)] hover:text-[var(--color-text)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]"
+      >
+        <X size={14} />
+      </button>
+    </li>
+  );
+}

--- a/src/features/notification/ui/notification-toaster.test.tsx
+++ b/src/features/notification/ui/notification-toaster.test.tsx
@@ -1,0 +1,196 @@
+import { readFileSync } from "node:fs";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import i18next from "i18next";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { type ToastRequest, useToastStore } from "../model/toast-store";
+import { NotificationToaster } from "./notification-toaster";
+
+const apiGetMock = vi.hoisted(() => vi.fn());
+const apiPostMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/shared/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api")>()),
+  apiClient: { get: apiGetMock, post: apiPostMock },
+}));
+
+const testI18n = i18next.createInstance();
+
+const infoToast: ToastRequest = { typeKey: "platform.lead-created" };
+const successToast: ToastRequest = {
+  typeKey: "company.role-assigned",
+  params: { roleName: "Payroll Manager" },
+};
+const warningToast: ToastRequest = { typeKey: "platform.conversion-requested" };
+const dangerToast: ToastRequest = { ...infoToast, tone: "danger" };
+
+/** The exit motion runs before the toast leaves the stack, so every removal costs 120ms more. */
+const EXIT_MS = 120;
+
+function renderToaster() {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <NotificationToaster />
+    </I18nextProvider>,
+  );
+}
+
+function showToast(request: ToastRequest) {
+  act(() => useToastStore.getState().showToast(request));
+}
+
+function advanceBy(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+/**
+ * Two ticks, not one: the expiring toast re-renders before it schedules its exit motion, so a
+ * single `advanceTimersByTime` spanning both would run past the exit timer before it exists.
+ */
+function advanceToRemoval(ms: number) {
+  advanceBy(ms);
+  advanceBy(EXIT_MS);
+}
+
+function toastStack() {
+  return screen.getByRole("list");
+}
+
+describe("NotificationToaster", () => {
+  beforeAll(async () => {
+    await testI18n.init({
+      lng: "en",
+      fallbackLng: "en",
+      ns: ["notification"],
+      defaultNS: "notification",
+      interpolation: { escapeValue: false },
+      resources: {
+        en: {
+          notification: JSON.parse(readFileSync("public/locales/en/notification.json", "utf8")),
+        },
+      },
+    });
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    useToastStore.setState({ toasts: [], earlierCount: 0 });
+  });
+
+  it("announces arrivals through a polite live region and labels the dismiss control", () => {
+    renderToaster();
+    showToast(infoToast);
+
+    expect(screen.getByRole("region", { name: "Recent notifications" })).toBeInTheDocument();
+    expect(toastStack()).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("New lead registered")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss notification" })).toBeInTheDocument();
+  });
+
+  it("dismisses info and success toasts after 5s", () => {
+    renderToaster();
+    showToast(infoToast);
+    showToast(successToast);
+
+    advanceBy(4_999);
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+
+    advanceToRemoval(1);
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+
+  it("holds a warning toast for 7s", () => {
+    renderToaster();
+    showToast(warningToast);
+
+    advanceBy(6_999);
+    expect(screen.getByText("Conversion request submitted")).toBeInTheDocument();
+
+    advanceToRemoval(1);
+    expect(screen.queryByText("Conversion request submitted")).not.toBeInTheDocument();
+  });
+
+  it("keeps a danger toast until it is dismissed by hand", () => {
+    renderToaster();
+    showToast(dangerToast);
+
+    advanceBy(60_000);
+    expect(screen.getByText("New lead registered")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+    advanceBy(EXIT_MS);
+
+    expect(screen.queryByText("New lead registered")).not.toBeInTheDocument();
+  });
+
+  it("shows at most three toasts and folds the rest into the earlier pill", () => {
+    renderToaster();
+
+    for (let index = 0; index < 5; index += 1) {
+      showToast(warningToast);
+    }
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getByText("+2 earlier")).toBeInTheDocument();
+  });
+
+  it("drops the earlier pill once the stack has emptied", () => {
+    renderToaster();
+
+    for (let index = 0; index < 4; index += 1) {
+      showToast(infoToast);
+    }
+
+    expect(screen.getByText("+1 earlier")).toBeInTheDocument();
+
+    advanceToRemoval(5_000);
+
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+    expect(screen.queryByText("+1 earlier")).not.toBeInTheDocument();
+  });
+
+  it("pauses the dismiss clock while the pointer rests on the stack", () => {
+    renderToaster();
+    showToast(infoToast);
+
+    advanceBy(3_000);
+    fireEvent.pointerOver(toastStack());
+
+    advanceBy(30_000);
+    expect(screen.getByText("New lead registered")).toBeInTheDocument();
+
+    fireEvent.pointerOut(toastStack());
+
+    advanceBy(1_900);
+    expect(screen.getByText("New lead registered")).toBeInTheDocument();
+
+    advanceToRemoval(100);
+    expect(screen.queryByText("New lead registered")).not.toBeInTheDocument();
+  });
+
+  it("dismisses without touching the server — dismiss is not read", () => {
+    renderToaster();
+    showToast(infoToast);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notification" }));
+    advanceBy(EXIT_MS);
+
+    expect(apiGetMock).not.toHaveBeenCalled();
+    expect(apiPostMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a type key the catalog mirror does not know", () => {
+    renderToaster();
+    showToast({ typeKey: "platform.not-in-the-mirror" });
+
+    expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/notification/ui/notification-toaster.tsx
+++ b/src/features/notification/ui/notification-toaster.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useToastStore } from "../model/toast-store";
+import { NotificationToastCard } from "./notification-toast";
+import { ToastDevTrigger } from "./toast-dev-trigger";
+
+/**
+ * The app-wide toast stack: bottom inline-end, newest closest to the corner, at most three cards
+ * with everything older folded into a count. Mounted once per shell.
+ */
+export function NotificationToaster() {
+  const { t } = useTranslation("notification", { useSuspense: false });
+  const toasts = useToastStore((state) => state.toasts);
+  const earlierCount = useToastStore((state) => state.earlierCount);
+  const [paused, setPaused] = useState(false);
+
+  return (
+    <div
+      role="region"
+      aria-label={t("toast.region")}
+      className="pointer-events-none fixed bottom-4 end-4 z-50 flex w-[min(360px,calc(100vw-32px))] flex-col items-stretch gap-2"
+    >
+      {import.meta.env.DEV ? <ToastDevTrigger /> : null}
+
+      {earlierCount > 0 ? (
+        <p className="pointer-events-auto self-end rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-2)] px-2 py-0.5 text-[11px] font-medium tabular-nums text-[var(--color-text-muted)]">
+          {t("toast.earlier", { count: earlierCount })}
+        </p>
+      ) : null}
+
+      {/* The list owns the pointer surface so crossing the gap between two cards is not a leave. */}
+      <ol
+        aria-live="polite"
+        className="pointer-events-auto flex flex-col gap-2"
+        onPointerEnter={() => setPaused(true)}
+        onPointerLeave={() => setPaused(false)}
+      >
+        {toasts.map((toast) => (
+          <NotificationToastCard key={toast.id} toast={toast} paused={paused} />
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/features/notification/ui/toast-dev-trigger.tsx
+++ b/src/features/notification/ui/toast-dev-trigger.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@/shared/ui/button";
+import { type ToastRequest, type ToastTone, useToastStore } from "../model/toast-store";
+
+/**
+ * Scaffolding that stands in for the arrival feed until it is wired up (HRMS-UI#57): one button per
+ * tone so the stack, the pill and the sticky danger toast can be exercised by hand. Rendered only
+ * under `import.meta.env.DEV`, so its labels are intentionally untranslated. Delete this file and
+ * its mount in the toaster once toasts arrive from the feed.
+ */
+const demoToasts: Record<ToastTone, ToastRequest> = {
+  info: { typeKey: "platform.lead-created" },
+  success: { typeKey: "company.role-assigned", params: { roleName: "Payroll Manager" } },
+  warning: { typeKey: "platform.conversion-requested" },
+  danger: {
+    typeKey: "company.subscription-changed",
+    params: { planName: "Growth", status: "past due" },
+    tone: "danger",
+  },
+};
+
+export function ToastDevTrigger() {
+  const showToast = useToastStore((state) => state.showToast);
+
+  return (
+    <div className="pointer-events-auto flex flex-wrap justify-end gap-1">
+      {Object.entries(demoToasts).map(([tone, request]) => (
+        <Button key={tone} variant="subtle" size="xs" onClick={() => showToast(request)}>
+          {tone}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/widgets/app-shell/ui/app-shell.tsx
+++ b/src/widgets/app-shell/ui/app-shell.tsx
@@ -1,5 +1,6 @@
 import { Shield } from "lucide-react";
 import { type ReactNode, useCallback, useState, useSyncExternalStore } from "react";
+import { NotificationToaster } from "@/features/notification";
 import { adminNavGroups, companyNavGroups } from "../model/nav-items";
 import { Header } from "./header";
 import { Sidebar } from "./sidebar";
@@ -72,6 +73,8 @@ export function AppShell({ portal, children }: AppShellProps) {
           <div className="p-4 sm:p-5 lg:p-7">{children}</div>
         </main>
       </div>
+
+      <NotificationToaster />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Implements the production Toaster per #57, behavior locked by the prototype resolution:

- Toasts render bottom inline-end (`end-4`), mirroring under RTL via logical properties only — no direction JS
- Max 3 stacked; older ones collapse into a "+N earlier" pill that clears when the stack empties
- Durations per tone: info/success auto-dismiss at 5s, warning at 7s, danger sticky until dismissed
- Timers pause while the pointer rests on the stack and resume on leave, carrying the remaining time across pauses
- Motion is transform+opacity only — 180ms enter / 120ms exit with token easing — collapsed under reduced-motion by the global block
- Arrivals announce through a polite `aria-live` region inside a labelled region; the icon-only dismiss control is labelled (`aria-label` + `title`)
- Dismissal is presentation-only: dismiss ≠ read, zero server calls (covered by test)
- Copy builds through the same catalog mirror / i18n path as panel rows (copy keys, typed params, tone tiles); unknown type keys are skipped
- Dev-only trigger surface gated behind `import.meta.env.DEV` for hand-testing, documented for removal once arrival wiring lands

Closes #57

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` — 206 passing, incl. 9 new toaster tests covering every acceptance criterion
- [x] `bun run lint` (biome + steiger)