### PR TITLE
chore(notification): prototype teardown gate and cross-portal acceptance sweep (#59)

### DIFF
--- a/src/features/notification/model/toast-store.ts
+++ b/src/features/notification/model/toast-store.ts
@@ -16,7 +16,7 @@ export const TOAST_DURATION_MS: Record<ToastTone, number | null> = {
 };
 
 /** Beyond this the stack stops growing and older toasts collapse into the "+N earlier" pill. */
-export const MAX_VISIBLE_TOASTS = 3;
+const MAX_VISIBLE_TOASTS = 3;
 
 export interface ToastRequest {
   readonly typeKey: string;


### PR DESCRIPTION
Closes #59

## What changed

The closing sweep of the notification epic. The teardown half turned out to be a verification, not a deletion: the prototype (`ui/prototype/*`, `/prototype/notifications` route, list-style preference) lived only on the unmerged `prototype/notification-center` branch and never entered `feature/notification`. Sweeps across `src/`, `routeTree.gen.ts`, nav items, i18n locales, and the preferences store found zero references — there was nothing to delete. The one dangling surface that did exist was an unused `export` on `MAX_VISIBLE_TOASTS`; it is now module-private (the react-doctor `deslop/unused-export` true positive).

## Acceptance sweep

- **One exported center, both portals** — `NotificationBell` + `NotificationToaster` are the slice's only public exports, mounted once each in `widgets/app-shell`, which `/admin` and `/company` shells render identically; the slice imports nothing above `shared`. Steiger green.
- **Theming / direction** — panel, rows, badge, and toasts use CSS custom properties and logical properties exclusively (`end`, `-me-`, explicit `ltr:/rtl:` variants on the panel origin); copy tests render every v1 catalog type in en + ar.
- **Cadence contract** — 30s idle default, `x-poll-interval` override, ETag 304 returning the cached object identity untouched, instant refetch on focus, paused while hidden: pinned by `poll-cadence.test`, `unread-count.test`, and `use-notification-arrivals.test`.
- **Lifecycle** — optimistic seen/read with snapshot rollback demonstrated in `notification-lifecycle.test`; dismiss never touches the server (toaster test).
- **Keyboard & a11y** — bell focus → panel open → Tab trap → row activation → mark-all covered by `notification-bell.test`; aria labels on the icon-only bell and toast dismiss; polite live region announces arrivals.
- **Badge** — caps at "99+" (tested) and derives solely from the count endpoint query.

## Gates

`tsc -b` clean · `biome check` + `steiger src` clean · vitest 220/220 · react-doctor advisory scan run — one true positive fixed here, remaining notification-slice findings triaged as false positives (intentional, commented dep arrays; invalidation present via the shared settle helper; sort operates on a fresh copy).

Human step left open on purpose: a visual light/dark × LTR/RTL pass in a running browser against the live backend.
