### PR TITLE
feat(notification): reader-chosen list style, hover copy, and a toast for new Leads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# HRMS UI — domain glossary
+
+The language of the HRMS frontend. Terms here are implementation-free; when code
+and this file disagree, one of them is wrong — fix it in the same change.
+
+## Notification center
+
+**Notification** — a server-generated event card addressed to one identity scope
+(company member or platform admin). Carries a type key, importance, params, and
+lifecycle timestamps.
+
+**Unseen** — a notification the user's eyes never landed on (`seen_at` and
+`read_at` both null). Unseen notifications count toward the bell's badge number.
+
+**Unread** — a notification that has been presented (seen) but not yet acted on
+(`read_at` null). Renders with settled styling; does not count toward the badge.
+
+**Read** — a notification the user explicitly activated or bulk-marked
+(`read_at` set). Renders muted.
+
+**Seen** — the presentation write: stamping that a rendered row was shown to the
+user. Drains the badge for the rows it covers. Distinct from read — dismissing a
+toast is neither seen nor read.
+
+**Badge count** — the number on the bell: exactly the unseen total from the
+unread-count endpoint. Never derived from the feed cache.
+
+**List style** — the user's chosen presentation shape of the notification list:
+`panel` (anchored dropdown), `sheet` (end-side sheet over a scrim), or `flat`
+(compact dropdown, no recency grouping, All/Unread chips). A presentation
+preference; it changes how the list renders, never what it contains.
+
+**Recency bucket** — the Today / Yesterday / Earlier grouping used by the panel
+and sheet shapes. The flat shape deliberately has none.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,5 +30,14 @@ unread-count endpoint. Never derived from the feed cache.
 (compact dropdown, no recency grouping, All/Unread chips). A presentation
 preference; it changes how the list renders, never what it contains.
 
+**Shape** — one of the three renderings of the notification list the **list
+style** selects: `panel`, `sheet`, `flat`. Shapes differ only in chrome and
+grouping; the feed, the lifecycle writes, and what a row means are the same in
+all three.
+
+**Center view** — what the open shape is currently showing: the `feed`, or the
+`settings` style picker swapped in over it. The view outlives a shape change,
+so picking a style leaves the picker open inside the new shape.
+
 **Recency bucket** — the Today / Yesterday / Earlier grouping used by the panel
 and sheet shapes. The flat shape deliberately has none.

--- a/docs/adr/0003-notification-list-style-preference.md
+++ b/docs/adr/0003-notification-list-style-preference.md
@@ -1,0 +1,47 @@
+# 0003 — Notification list style is a user preference with three shapes
+
+Date: 2026-08-25
+Status: Accepted
+
+## Context
+
+The notification-center prototype (issue #51) validated three presentation
+shapes for the notification list: an anchored dropdown **panel**, an end-side
+**sheet** over a scrim, and a compact **flat** list with All/Unread chips. The
+production epic shipped panel-only, and the closing sweep (#59) removed the
+prototype's list-style preference as dead state, declaring v1 "panel-only —
+Variant A".
+
+Users then asked for the choice back: the shape is genuinely a matter of taste
+and screen habit, and each validated shape serves a different one — the panel
+for quick glances, the sheet for focused triage, the flat list for high-volume
+scanning with filtering.
+
+## Decision
+
+The list style ships as a **user preference** with all three shapes selectable:
+`panel`, `sheet`, `flat`.
+
+- The setting lives **inside the notification center** (a style-picker view
+  swapped into whichever shape is open), not on a settings route.
+- Each option previews via a **live miniature** built from the same design
+  tokens — never static images — so theme (light/dark) and direction
+  (LTR/RTL) are always faithful.
+- The choice persists **client-side** in the preferences store, like theme and
+  locale. It is per-browser until server-synced preferences exist.
+- The bell's badge is **the count pill under every shape**; the badge is the
+  center's identity, not the list's.
+- The sheet and flat shapes carry the prototype's extra affordances: per-row
+  mark-read (which also gives non-navigable rows an individual read path) and,
+  for flat, All/Unread chips.
+
+## Consequences
+
+- The bell becomes a dispatcher: it renders whichever shape the preference
+  selects, over the same feed, lifecycle mutations, and arrival watcher.
+- The badge contract from the epic (caps at 99+, derives solely from the
+  unread-count endpoint) is unchanged and shape-independent.
+- A future server-side preferences endpoint can migrate the persisted store
+  version without UI changes.
+- The prototype branch stays dead; the shapes are rebuilt as production
+  components on the real feed, not ported from the mock-driven prototypes.

--- a/public/locales/ar/notification.json
+++ b/public/locales/ar/notification.json
@@ -31,5 +31,20 @@
   "notifications.company.role-assigned.title": "تم إسناد دور",
   "notifications.company.role-assigned.body": "تم منحك دور {{roleName}}.",
   "notifications.company.user-joined.title": "انضم عضو جديد",
-  "notifications.company.user-joined.body": "تم قبول دعوة وانضم عضو جديد إلى شركتك."
+  "notifications.company.user-joined.body": "تم قبول دعوة وانضم عضو جديد إلى شركتك.",
+  "row.markRead": "تعليم كمقروء",
+  "sheet.close": "إغلاق الإشعارات",
+  "filter.label": "تصفية الإشعارات",
+  "filter.all": "الكل",
+  "filter.unread": "غير المقروءة",
+  "picker.open": "إعدادات الإشعارات",
+  "picker.title": "شكل القائمة",
+  "picker.back": "العودة إلى الإشعارات",
+  "picker.hint": "اختر الطريقة التي يفتح بها مركز الإشعارات. يُحفظ الاختيار على هذا الجهاز.",
+  "style.panel.name": "لوحة منسدلة",
+  "style.panel.hint": "قائمة منسدلة أسفل الجرس، مجمّعة حسب اليوم. الأنسب لنظرة سريعة.",
+  "style.sheet.name": "لوحة جانبية",
+  "style.sheet.hint": "لوحة تنزلق من الجانب فوق الصفحة بصفوف أوسع. الأنسب لمعالجة الإشعارات.",
+  "style.flat.name": "قائمة مضغوطة",
+  "style.flat.hint": "الأحدث أولاً بلا عناوين أيام، مع تصفية الكل أو غير المقروءة. الأنسب للإشعارات الكثيرة."
 }

--- a/public/locales/en/notification.json
+++ b/public/locales/en/notification.json
@@ -31,5 +31,20 @@
   "notifications.company.role-assigned.title": "Role assigned",
   "notifications.company.role-assigned.body": "You were granted the {{roleName}} role.",
   "notifications.company.user-joined.title": "New member joined",
-  "notifications.company.user-joined.body": "An invitation was accepted and a new member joined your company."
+  "notifications.company.user-joined.body": "An invitation was accepted and a new member joined your company.",
+  "row.markRead": "Mark as read",
+  "sheet.close": "Close notifications",
+  "filter.label": "Filter notifications",
+  "filter.all": "All",
+  "filter.unread": "Unread",
+  "picker.open": "Notification settings",
+  "picker.title": "List style",
+  "picker.back": "Back to notifications",
+  "picker.hint": "Choose how the notification center opens. The choice is kept on this device.",
+  "style.panel.name": "Panel",
+  "style.panel.hint": "A dropdown under the bell, grouped by day. Best for a quick glance.",
+  "style.sheet.name": "Sheet",
+  "style.sheet.hint": "A side sheet over the page, with roomier rows. Best for working through the feed.",
+  "style.flat.name": "Compact list",
+  "style.flat.hint": "Newest first with no day headings, filtered to All or Unread. Best for a busy feed."
 }

--- a/src/features/notification/lib/roving-choice.ts
+++ b/src/features/notification/lib/roving-choice.ts
@@ -1,0 +1,29 @@
+import type { TextDirection } from "@/shared/i18n";
+
+/**
+ * Where an arrow key lands in a group of choices, or `null` when the key is not one of them.
+ * Vertical arrows walk the list; the horizontal pair follows reading order, so "next" is on
+ * the left in Arabic.
+ */
+export function nextRovingChoice<T>(
+  key: string,
+  direction: TextDirection,
+  options: readonly T[],
+  current: T,
+): T | null {
+  const step = arrowStep(key, direction);
+  if (step === 0) return null;
+
+  const index = options.indexOf(current);
+  return options[(index + step + options.length) % options.length] ?? null;
+}
+
+function arrowStep(key: string, direction: TextDirection): number {
+  const forward = direction === "rtl" ? -1 : 1;
+
+  if (key === "ArrowDown") return 1;
+  if (key === "ArrowUp") return -1;
+  if (key === "ArrowRight") return forward;
+  if (key === "ArrowLeft") return -forward;
+  return 0;
+}

--- a/src/features/notification/lib/roving-choice.ts
+++ b/src/features/notification/lib/roving-choice.ts
@@ -18,6 +18,11 @@ export function nextRovingChoice<T>(
   return options[(index + step + options.length) % options.length] ?? null;
 }
 
+/** Moves the group's single tab stop onto one option, which must carry `data-choice`. */
+export function focusRovingChoice(container: HTMLElement | null, choice: string) {
+  container?.querySelector<HTMLButtonElement>(`[data-choice="${choice}"]`)?.focus();
+}
+
 function arrowStep(key: string, direction: TextDirection): number {
   const forward = direction === "rtl" ? -1 : 1;
 

--- a/src/features/notification/lib/use-body-scroll-lock.ts
+++ b/src/features/notification/lib/use-body-scroll-lock.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+/**
+ * Holds the page still while a shape covers it. The scrollbar's width is handed back as
+ * padding, because letting the page widen underneath the scrim reads as a jump.
+ */
+export function useBodyScrollLock(locked: boolean) {
+  useEffect(() => {
+    if (!locked) return;
+
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    const previousPadding = body.style.paddingInlineEnd;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+    body.style.overflow = "hidden";
+    if (scrollbarWidth > 0) body.style.paddingInlineEnd = `${scrollbarWidth}px`;
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      body.style.paddingInlineEnd = previousPadding;
+    };
+  }, [locked]);
+}

--- a/src/features/notification/lib/use-notification-arrivals.test.tsx
+++ b/src/features/notification/lib/use-notification-arrivals.test.tsx
@@ -130,6 +130,22 @@ describe("useNotificationArrivals", () => {
     expect(toast?.typeKey).toBe("company.role-assigned");
   });
 
+  it("announces a new Lead, the one platform arrival worth interrupting for", async () => {
+    feedGetMock
+      .mockReturnValueOnce(feedPage([historyItem()]))
+      .mockReturnValueOnce(
+        feedPage([feedItem(2, "platform.lead-created", "2026-08-25T09:30:00.000Z")]),
+      );
+
+    renderHook(() => useNotificationArrivals());
+    await settlePoll();
+
+    await focusTick();
+
+    const [toast] = useToastStore.getState().toasts;
+    expect(toast?.typeKey).toBe("platform.lead-created");
+  });
+
   it("lets a normal-importance arrival wait in the bell", async () => {
     feedGetMock
       .mockReturnValueOnce(feedPage([historyItem()]))

--- a/src/features/notification/lib/use-notification-center.ts
+++ b/src/features/notification/lib/use-notification-center.ts
@@ -30,6 +30,8 @@ export interface NotificationCenter {
   readonly isFetchingNextPage: boolean;
   readonly isMarkingAllRead: boolean;
   readonly fetchNextPage: () => void;
+  /** Reading a row by opening it: an already-read row owes the server nothing. */
+  readonly activate: (row: NotificationRowModel) => void;
   readonly markRead: (id: number) => void;
   readonly markAllRead: (onSuccess: () => void) => void;
 }
@@ -82,6 +84,9 @@ export function useNotificationCenter(open: boolean): NotificationCenter {
     isFetchingNextPage,
     isMarkingAllRead: markAllRead.isPending,
     fetchNextPage: () => void fetchNextPage(),
+    activate: (row) => {
+      if (row.state !== "read") markRead.mutate(row.item.id);
+    },
     markRead: (id) => markRead.mutate(id),
     markAllRead: (onSuccess) => markAllRead.mutate(undefined, { onSuccess }),
   };

--- a/src/features/notification/lib/use-notification-center.ts
+++ b/src/features/notification/lib/use-notification-center.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+import type { NotificationFeedItem } from "../api/notification-feed";
+import { useNotificationFeed } from "../api/notification-feed";
+import {
+  SEEN_BATCH_LIMIT,
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useMarkNotificationsSeen,
+} from "../api/notification-lifecycle";
+import { NOTIFICATION_CATALOG } from "../model/notification-catalog";
+import {
+  type NotificationRowState,
+  notificationRowState,
+  useBulkReadCursor,
+} from "../model/notification-read-state";
+
+export interface NotificationRowModel {
+  readonly item: NotificationFeedItem;
+  readonly state: NotificationRowState;
+}
+
+export interface NotificationCenter {
+  readonly rows: readonly NotificationRowModel[];
+  readonly isPending: boolean;
+  readonly isError: boolean;
+  readonly hasUnread: boolean;
+  /** True when a seen, read, or mark-all write failed and the reader is owed an explanation. */
+  readonly lifecycleFailed: boolean;
+  readonly hasNextPage: boolean;
+  readonly isFetchingNextPage: boolean;
+  readonly isMarkingAllRead: boolean;
+  readonly fetchNextPage: () => void;
+  readonly markRead: (id: number) => void;
+  readonly markAllRead: (onSuccess: () => void) => void;
+}
+
+/**
+ * Everything the three shapes share: one feed, one seen-on-open write, one set of lifecycle
+ * mutations. The shapes differ in chrome and grouping only, so none of this is duplicated
+ * per shape and a row means the same thing in all of them.
+ */
+export function useNotificationCenter(open: boolean): NotificationCenter {
+  const { data, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useNotificationFeed(open);
+  const bulkReadCursorAt = useBulkReadCursor((cursor) => cursor.cursorAt);
+  const markSeen = useMarkNotificationsSeen();
+  const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
+
+  // A type the mirror does not know cannot be rendered, and must not leave an empty bucket behind.
+  const rows: NotificationRowModel[] = (data ?? [])
+    .filter((item) => NOTIFICATION_CATALOG.has(item.typeKey))
+    .map((item) => ({ item, state: notificationRowState(item, bulkReadCursorAt) }));
+
+  const unseenIds = rows.filter((row) => row.state === "unseen").map((row) => row.item.id);
+  const unseenKey = unseenIds.join(",");
+  const seenSent = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      seenSent.current = false;
+      return;
+    }
+
+    if (seenSent.current || unseenIds.length === 0) return;
+
+    // Reopening with nothing unseen left never reaches this point, which is what keeps the
+    // contract at one request per open rather than one per render.
+    seenSent.current = true;
+    markSeen.mutate(unseenIds.slice(0, SEEN_BATCH_LIMIT));
+    // Keyed on the id list rather than the feed object: the rows re-render far more often than
+    // their identities change, and only a changed identity can owe a request.
+  }, [open, unseenKey]);
+
+  return {
+    rows,
+    isPending,
+    isError,
+    hasUnread: rows.some((row) => row.state !== "read"),
+    lifecycleFailed: markSeen.isError || markRead.isError || markAllRead.isError,
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+    isMarkingAllRead: markAllRead.isPending,
+    fetchNextPage: () => void fetchNextPage(),
+    markRead: (id) => markRead.mutate(id),
+    markAllRead: (onSuccess) => markAllRead.mutate(undefined, { onSuccess }),
+  };
+}

--- a/src/features/notification/lib/use-overlay-dismiss.ts
+++ b/src/features/notification/lib/use-overlay-dismiss.ts
@@ -1,0 +1,87 @@
+import { type RefObject, useEffect } from "react";
+
+const FOCUSABLE_SELECTOR = 'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])';
+
+interface OverlayDismissOptions {
+  open: boolean;
+  overlayRef: RefObject<HTMLElement | null>;
+  triggerRef: RefObject<HTMLElement | null>;
+  onClose: () => void;
+}
+
+/**
+ * The dismissal contract every notification shape shares: focus moves in on open, Tab cycles
+ * inside, Escape closes and hands focus back to the trigger, and a pointer landing anywhere
+ * else closes without taking focus with it. A shape that covers the page with a scrim gets
+ * scrim-click from the same rule — the scrim is outside the overlay.
+ */
+export function useOverlayDismiss({
+  open,
+  overlayRef,
+  triggerRef,
+  onClose,
+}: OverlayDismissOptions) {
+  useEffect(() => {
+    // Only when the overlay does not already hold focus: a shape that swaps in around an
+    // already-focused control must not pull focus back out to itself.
+    if (open && !overlayRef.current?.contains(document.activeElement)) {
+      overlayRef.current?.focus();
+    }
+  }, [open, overlayRef]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+        triggerRef.current?.focus();
+        return;
+      }
+
+      if (event.key === "Tab") keepFocusInOverlay(event, overlayRef.current);
+    }
+
+    // Focus stays where the click landed; only Escape hands it back to the trigger.
+    function onPointerDown(event: PointerEvent) {
+      const target = event.target;
+
+      if (!(target instanceof Node)) return;
+      if (overlayRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
+
+      onClose();
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+    };
+  }, [open, overlayRef, triggerRef, onClose]);
+}
+
+/** Tab cycles inside the open dialog instead of walking off into the page behind it. */
+function keepFocusInOverlay(event: KeyboardEvent, overlay: HTMLElement | null) {
+  if (!overlay) return;
+
+  const focusable = [...overlay.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+
+  if (focusable.length === 0) {
+    event.preventDefault();
+    overlay.focus();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const atEdge = event.shiftKey
+    ? document.activeElement === first
+    : document.activeElement === last;
+
+  if (!atEdge) return;
+
+  event.preventDefault();
+  (event.shiftKey ? last : first).focus();
+}

--- a/src/features/notification/model/notification-catalog.ts
+++ b/src/features/notification/model/notification-catalog.ts
@@ -80,7 +80,7 @@ function catalogEntry(
 
 export const NOTIFICATION_CATALOG: ReadonlyMap<string, NotificationTypeEntry> = new Map([
   catalogEntry("platform.lead-created", {
-    importance: "normal",
+    importance: "high",
     tone: "info",
     icon: UserPlus,
     route: () => ({ to: "/admin/leads" }),

--- a/src/features/notification/model/notification-list-style.ts
+++ b/src/features/notification/model/notification-list-style.ts
@@ -1,0 +1,7 @@
+import type { NotificationListStyle } from "@/shared/config";
+
+/** The order the picker offers the shapes in: quick glance, focused triage, high-volume scan. */
+export const NOTIFICATION_LIST_STYLES = ["panel", "sheet", "flat"] as const satisfies readonly [
+  NotificationListStyle,
+  ...NotificationListStyle[],
+];

--- a/src/features/notification/model/notification-list-style.ts
+++ b/src/features/notification/model/notification-list-style.ts
@@ -1,7 +1,8 @@
 import type { NotificationListStyle } from "@/shared/config";
 
 /** The order the picker offers the shapes in: quick glance, focused triage, high-volume scan. */
-export const NOTIFICATION_LIST_STYLES = ["panel", "sheet", "flat"] as const satisfies readonly [
-  NotificationListStyle,
-  ...NotificationListStyle[],
+export const NOTIFICATION_LIST_STYLES: readonly NotificationListStyle[] = [
+  "panel",
+  "sheet",
+  "flat",
 ];

--- a/src/features/notification/model/notification-shape.ts
+++ b/src/features/notification/model/notification-shape.ts
@@ -1,0 +1,15 @@
+import type { RefObject } from "react";
+
+/** Whether the open shape is showing the feed or the style picker swapped in over it. */
+export type NotificationCenterView = "feed" | "settings";
+
+/** What the bell hands whichever shape the reader chose; every shape reads the same props. */
+export interface NotificationShapeProps {
+  open: boolean;
+  overlayId: string;
+  overlayRef: RefObject<HTMLDivElement | null>;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  view: NotificationCenterView;
+  onClose: () => void;
+  onViewChange: (view: NotificationCenterView) => void;
+}

--- a/src/features/notification/model/notification-shape.ts
+++ b/src/features/notification/model/notification-shape.ts
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import type { NotificationCenter } from "../lib/use-notification-center";
 
 /** Whether the open shape is showing the feed or the style picker swapped in over it. */
 export type NotificationCenterView = "feed" | "settings";
@@ -6,6 +7,12 @@ export type NotificationCenterView = "feed" | "settings";
 /** What the bell hands whichever shape the reader chose; every shape reads the same props. */
 export interface NotificationShapeProps {
   open: boolean;
+  /**
+   * Owned by the bell, not by the shape: switching style unmounts one shape and mounts the
+   * next with the center already open, and a per-shape center would re-run its seen-on-open
+   * write for rows the reader has already been shown.
+   */
+  center: NotificationCenter;
   overlayId: string;
   overlayRef: RefObject<HTMLDivElement | null>;
   triggerRef: RefObject<HTMLButtonElement | null>;

--- a/src/features/notification/ui/notification-bell.test.tsx
+++ b/src/features/notification/ui/notification-bell.test.tsx
@@ -50,7 +50,11 @@ const session: AuthSession = {
   user: baseUser,
 };
 
-const now = new Date();
+/**
+ * A fixed midday "now": the recency buckets are calendar days, so a suite that reads the real
+ * clock puts its rows in different buckets when it runs a few minutes either side of midnight.
+ */
+const now = new Date("2026-08-25T12:00:00Z");
 const hoursAgo = (hours: number) => new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
 
 const leadRow: NotificationFeedItem = {
@@ -147,10 +151,12 @@ describe("NotificationBell", () => {
   });
 
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"], now, shouldAdvanceTime: true });
     useAuthStore.setState({ session, status: "authenticated" });
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
     vi.clearAllMocks();
     useBulkReadCursor.setState({ cursorAt: null });

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -1,58 +1,45 @@
 import { Bell } from "lucide-react";
-import { useEffect, useId, useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { type NotificationListStyle, usePreferencesStore } from "@/shared/config";
 import { Button } from "@/shared/ui/button";
 import { useUnreadNotificationCount } from "../api/unread-count";
+import type { NotificationCenterView, NotificationShapeProps } from "../model/notification-shape";
+import { NotificationFlat } from "./notification-flat";
 import { NotificationPanel } from "./notification-panel";
+import { NotificationSheet } from "./notification-sheet";
 
 const BADGE_COUNT_CAP = 99;
-
-const FOCUSABLE_SELECTOR = 'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])';
 
 export function NotificationBell() {
   const { t } = useTranslation("notification", { useSuspense: false });
   const { data } = useUnreadNotificationCount();
+  const listStyle = usePreferencesStore((preferences) => preferences.notificationListStyle);
   const [open, setOpen] = useState(false);
+  const [view, setView] = useState<NotificationCenterView>("feed");
   const bellRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const panelId = useId();
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const overlayId = useId();
 
   const unreadCount = data?.unreadCount ?? 0;
   const label = t("panel.title");
 
-  useEffect(() => {
-    if (!open) return;
+  function close() {
+    setOpen(false);
+    setView("feed");
+  }
 
-    panelRef.current?.focus();
-
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-        bellRef.current?.focus();
-        return;
-      }
-
-      if (event.key === "Tab") keepFocusInPanel(event, panelRef.current);
-    }
-
-    // Focus stays where the click landed; only Escape hands it back to the bell.
-    function onPointerDown(event: PointerEvent) {
-      const target = event.target;
-
-      if (!(target instanceof Node)) return;
-      if (panelRef.current?.contains(target) || bellRef.current?.contains(target)) return;
-
-      setOpen(false);
-    }
-
-    document.addEventListener("keydown", onKeyDown);
-    document.addEventListener("pointerdown", onPointerDown);
-
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-      document.removeEventListener("pointerdown", onPointerDown);
-    };
-  }, [open]);
+  // The view outlives the shape on purpose: picking a style in the picker swaps the shape
+  // around it, which is what makes the choice something the reader can see rather than guess.
+  const shapeProps: NotificationShapeProps = {
+    open,
+    overlayId,
+    overlayRef,
+    triggerRef: bellRef,
+    view,
+    onClose: close,
+    onViewChange: setView,
+  };
 
   return (
     <div className="relative">
@@ -66,8 +53,8 @@ export function NotificationBell() {
         }
         aria-haspopup="dialog"
         aria-expanded={open}
-        aria-controls={panelId}
-        onClick={() => setOpen((previous) => !previous)}
+        aria-controls={overlayId}
+        onClick={() => (open ? close() : setOpen(true))}
         leadingIcon={<Bell size={16} />}
         iconOnly
       />
@@ -80,38 +67,25 @@ export function NotificationBell() {
         </span>
       ) : null}
 
-      <NotificationPanel
-        open={open}
-        panelId={panelId}
-        panelRef={panelRef}
-        onClose={() => setOpen(false)}
-      />
+      <NotificationCenterShape listStyle={listStyle} {...shapeProps} />
     </div>
   );
 }
 
-/** Tab cycles inside the open dialog instead of walking off into the page behind it. */
-function keepFocusInPanel(event: KeyboardEvent, panel: HTMLDivElement | null) {
-  if (!panel) return;
+interface NotificationCenterShapeProps extends NotificationShapeProps {
+  listStyle: NotificationListStyle;
+}
 
-  const focusable = [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
-
-  if (focusable.length === 0) {
-    event.preventDefault();
-    panel.focus();
-    return;
+function NotificationCenterShape({ listStyle, ...shape }: NotificationCenterShapeProps) {
+  if (listStyle === "sheet") {
+    return <NotificationSheet {...shape} />;
   }
 
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  const atEdge = event.shiftKey
-    ? document.activeElement === first
-    : document.activeElement === last;
+  if (listStyle === "flat") {
+    return <NotificationFlat {...shape} />;
+  }
 
-  if (!atEdge) return;
-
-  event.preventDefault();
-  (event.shiftKey ? last : first).focus();
+  return <NotificationPanel {...shape} />;
 }
 
 function formatBadgeCount(count: number) {

--- a/src/features/notification/ui/notification-bell.tsx
+++ b/src/features/notification/ui/notification-bell.tsx
@@ -1,15 +1,22 @@
 import { Bell } from "lucide-react";
-import { useId, useRef, useState } from "react";
+import { type ComponentType, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type NotificationListStyle, usePreferencesStore } from "@/shared/config";
 import { Button } from "@/shared/ui/button";
 import { useUnreadNotificationCount } from "../api/unread-count";
+import { useNotificationCenter } from "../lib/use-notification-center";
 import type { NotificationCenterView, NotificationShapeProps } from "../model/notification-shape";
 import { NotificationFlat } from "./notification-flat";
 import { NotificationPanel } from "./notification-panel";
 import { NotificationSheet } from "./notification-sheet";
 
 const BADGE_COUNT_CAP = 99;
+
+const shapeComponent: Record<NotificationListStyle, ComponentType<NotificationShapeProps>> = {
+  panel: NotificationPanel,
+  sheet: NotificationSheet,
+  flat: NotificationFlat,
+};
 
 export function NotificationBell() {
   const { t } = useTranslation("notification", { useSuspense: false });
@@ -21,8 +28,10 @@ export function NotificationBell() {
   const overlayRef = useRef<HTMLDivElement>(null);
   const overlayId = useId();
 
+  const center = useNotificationCenter(open);
   const unreadCount = data?.unreadCount ?? 0;
   const label = t("panel.title");
+  const Shape = shapeComponent[listStyle];
 
   function close() {
     setOpen(false);
@@ -33,6 +42,7 @@ export function NotificationBell() {
   // around it, which is what makes the choice something the reader can see rather than guess.
   const shapeProps: NotificationShapeProps = {
     open,
+    center,
     overlayId,
     overlayRef,
     triggerRef: bellRef,
@@ -54,7 +64,10 @@ export function NotificationBell() {
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={overlayId}
-        onClick={() => (open ? close() : setOpen(true))}
+        onClick={() => {
+          if (open) close();
+          else setOpen(true);
+        }}
         leadingIcon={<Bell size={16} />}
         iconOnly
       />
@@ -67,25 +80,9 @@ export function NotificationBell() {
         </span>
       ) : null}
 
-      <NotificationCenterShape listStyle={listStyle} {...shapeProps} />
+      <Shape {...shapeProps} />
     </div>
   );
-}
-
-interface NotificationCenterShapeProps extends NotificationShapeProps {
-  listStyle: NotificationListStyle;
-}
-
-function NotificationCenterShape({ listStyle, ...shape }: NotificationCenterShapeProps) {
-  if (listStyle === "sheet") {
-    return <NotificationSheet {...shape} />;
-  }
-
-  if (listStyle === "flat") {
-    return <NotificationFlat {...shape} />;
-  }
-
-  return <NotificationPanel {...shape} />;
 }
 
 function formatBadgeCount(count: number) {

--- a/src/features/notification/ui/notification-bucket-list.tsx
+++ b/src/features/notification/ui/notification-bucket-list.tsx
@@ -1,14 +1,14 @@
 import { useTranslation } from "react-i18next";
 import type { NotificationRowModel } from "../lib/use-notification-center";
 import { RECENCY_BUCKETS, type RecencyBucket, recencyBucketOf } from "../model/recency-bucket";
-import { NotificationRow } from "./notification-row";
+import { NotificationRow, type NotificationRowDensity } from "./notification-row";
 
 interface NotificationBucketListProps {
   rows: readonly NotificationRowModel[];
   onActivate: (row: NotificationRowModel) => void;
   /** Passed on to every row that can still be read; absent leaves rows without the control. */
   onMarkRead?: (row: NotificationRowModel) => void;
-  density?: "compact" | "roomy";
+  density?: NotificationRowDensity;
 }
 
 /** The feed under calendar-day headings — how the panel and the sheet both group their rows. */
@@ -43,7 +43,7 @@ interface BucketSectionProps {
   rows: readonly NotificationRowModel[];
   onActivate: (row: NotificationRowModel) => void;
   onMarkRead?: (row: NotificationRowModel) => void;
-  density?: "compact" | "roomy";
+  density?: NotificationRowDensity;
 }
 
 function BucketSection({

--- a/src/features/notification/ui/notification-bucket-list.tsx
+++ b/src/features/notification/ui/notification-bucket-list.tsx
@@ -1,0 +1,83 @@
+import { useTranslation } from "react-i18next";
+import type { NotificationRowModel } from "../lib/use-notification-center";
+import { RECENCY_BUCKETS, type RecencyBucket, recencyBucketOf } from "../model/recency-bucket";
+import { NotificationRow } from "./notification-row";
+
+interface NotificationBucketListProps {
+  rows: readonly NotificationRowModel[];
+  onActivate: (row: NotificationRowModel) => void;
+  /** Passed on to every row that can still be read; absent leaves rows without the control. */
+  onMarkRead?: (row: NotificationRowModel) => void;
+  density?: "compact" | "roomy";
+}
+
+/** The feed under calendar-day headings — how the panel and the sheet both group their rows. */
+export function NotificationBucketList({
+  rows,
+  onActivate,
+  onMarkRead,
+  density,
+}: NotificationBucketListProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+
+  return (
+    <>
+      {RECENCY_BUCKETS.map((bucket) => (
+        <BucketSection
+          key={bucket}
+          bucket={bucket}
+          label={t(`panel.buckets.${bucket}`)}
+          rows={rows.filter((row) => recencyBucketOf(row.item.createdAt) === bucket)}
+          onActivate={onActivate}
+          onMarkRead={onMarkRead}
+          density={density}
+        />
+      ))}
+    </>
+  );
+}
+
+interface BucketSectionProps {
+  bucket: RecencyBucket;
+  label: string;
+  rows: readonly NotificationRowModel[];
+  onActivate: (row: NotificationRowModel) => void;
+  onMarkRead?: (row: NotificationRowModel) => void;
+  density?: "compact" | "roomy";
+}
+
+function BucketSection({
+  bucket,
+  label,
+  rows,
+  onActivate,
+  onMarkRead,
+  density,
+}: BucketSectionProps) {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby={`notification-bucket-${bucket}`}>
+      <h3
+        id={`notification-bucket-${bucket}`}
+        className="sticky top-0 bg-[var(--color-surface)] px-4 pb-1 pt-3 text-[11px] font-semibold uppercase tracking-widest text-[var(--color-text-faint)]"
+      >
+        {label}
+      </h3>
+      <ul>
+        {rows.map((row) => (
+          <NotificationRow
+            key={row.item.id}
+            item={row.item}
+            state={row.state}
+            onActivate={() => onActivate(row)}
+            onMarkRead={onMarkRead ? () => onMarkRead(row) : undefined}
+            density={density}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/notification/ui/notification-feed-status.tsx
+++ b/src/features/notification/ui/notification-feed-status.tsx
@@ -1,0 +1,54 @@
+import { BellOff } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface NotificationFeedStatusProps {
+  isPending: boolean;
+  isError: boolean;
+  isEmpty: boolean;
+}
+
+/** What a shape shows instead of rows: still loading, could not load, or nothing to show. */
+export function NotificationFeedStatus({
+  isPending,
+  isError,
+  isEmpty,
+}: NotificationFeedStatusProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+
+  if (isPending) {
+    return <FeedMessage>{t("panel.loading")}</FeedMessage>;
+  }
+
+  if (isError) {
+    return <FeedMessage>{t("panel.error")}</FeedMessage>;
+  }
+
+  if (!isEmpty) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
+      <span
+        aria-hidden="true"
+        className="flex size-9 items-center justify-center rounded-full bg-[var(--color-surface-2)] text-[var(--color-text-faint)]"
+      >
+        <BellOff size={16} />
+      </span>
+      <p className="text-[13px] font-medium text-[var(--color-text)]">{t("panel.empty.title")}</p>
+      <p className="max-w-[240px] text-xs leading-relaxed text-[var(--color-text-faint)]">
+        {t("panel.empty.hint")}
+      </p>
+    </div>
+  );
+}
+
+interface FeedMessageProps {
+  children: string;
+}
+
+function FeedMessage({ children }: FeedMessageProps) {
+  return (
+    <p className="px-4 py-8 text-center text-[13px] text-[var(--color-text-muted)]">{children}</p>
+  );
+}

--- a/src/features/notification/ui/notification-flat.tsx
+++ b/src/features/notification/ui/notification-flat.tsx
@@ -1,0 +1,185 @@
+import { CheckCheck, Settings2 } from "lucide-react";
+import { type KeyboardEvent, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { usePreferencesStore } from "@/shared/config";
+import { getDirection } from "@/shared/i18n";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { nextRovingChoice } from "../lib/roving-choice";
+import { useNotificationCenter } from "../lib/use-notification-center";
+import { useOverlayDismiss } from "../lib/use-overlay-dismiss";
+import type { NotificationShapeProps } from "../model/notification-shape";
+import { NotificationFeedStatus } from "./notification-feed-status";
+import { NotificationLifecycleAlert } from "./notification-lifecycle-alert";
+import { NotificationRow } from "./notification-row";
+import { NotificationStylePicker } from "./notification-style-picker";
+
+const FEED_FILTERS = ["all", "unread"] as const;
+
+type FeedFilter = (typeof FEED_FILTERS)[number];
+
+/** The compact list: newest first, no day headings, and a filter for the unread pile. */
+export function NotificationFlat({
+  open,
+  overlayId,
+  overlayRef,
+  triggerRef,
+  view,
+  onClose,
+  onViewChange,
+}: NotificationShapeProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+  const locale = usePreferencesStore((preferences) => preferences.locale);
+  const center = useNotificationCenter(open);
+  const [filter, setFilter] = useState<FeedFilter>("all");
+  const filtersRef = useRef<HTMLDivElement>(null);
+
+  useOverlayDismiss({ open, overlayRef, triggerRef, onClose });
+
+  function onFilterKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    const next = nextRovingChoice(event.key, getDirection(locale), FEED_FILTERS, filter);
+    if (!next) return;
+
+    event.preventDefault();
+    setFilter(next);
+    filtersRef.current?.querySelector<HTMLButtonElement>(`[data-filter="${next}"]`)?.focus();
+  }
+
+  const rows =
+    filter === "unread" ? center.rows.filter((row) => row.state !== "read") : center.rows;
+
+  return (
+    <div
+      ref={overlayRef}
+      id={overlayId}
+      role="dialog"
+      aria-label={t("panel.title")}
+      tabIndex={-1}
+      inert={!open}
+      aria-hidden={!open}
+      className={cn(
+        "absolute top-[calc(100%+8px)] end-0 z-40 flex max-h-[min(560px,calc(100dvh-88px))] w-[352px] max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-md)] outline-none",
+        "origin-top transition-[transform,opacity,visibility] ease-[var(--motion-easing)] ltr:origin-top-right rtl:origin-top-left",
+        open
+          ? "visible translate-y-0 scale-100 opacity-100 duration-[var(--motion-base)]"
+          : "pointer-events-none invisible -translate-y-1 scale-[0.98] opacity-0 duration-[var(--motion-fast)]",
+      )}
+    >
+      {view === "settings" ? (
+        <NotificationStylePicker onBack={() => onViewChange("feed")} />
+      ) : (
+        <>
+          <header className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--color-border)] px-3 py-2.5">
+            <div
+              ref={filtersRef}
+              role="radiogroup"
+              aria-label={t("filter.label")}
+              onKeyDown={onFilterKeyDown}
+              className="flex items-center gap-0.5 rounded-[var(--radius-md)] bg-[var(--color-surface-2)] p-0.5"
+            >
+              {FEED_FILTERS.map((option) => (
+                <FilterSegment
+                  key={option}
+                  filter={option}
+                  label={t(`filter.${option}`)}
+                  selected={filter === option}
+                  onSelect={() => setFilter(option)}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-1">
+              <Button
+                intent="toggle"
+                size="iconXs"
+                title={t("panel.markAllRead")}
+                aria-label={t("panel.markAllRead")}
+                disabled={!center.hasUnread}
+                isLoading={center.isMarkingAllRead}
+                onClick={() => center.markAllRead(() => overlayRef.current?.focus())}
+                leadingIcon={<CheckCheck size={14} />}
+                iconOnly
+              />
+              <Button
+                intent="toggle"
+                size="iconXs"
+                title={t("picker.open")}
+                aria-label={t("picker.open")}
+                onClick={() => onViewChange("settings")}
+                leadingIcon={<Settings2 size={14} />}
+                iconOnly
+              />
+            </div>
+          </header>
+
+          <NotificationLifecycleAlert failed={center.lifecycleFailed} />
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <NotificationFeedStatus
+              isPending={center.isPending}
+              isError={center.isError}
+              isEmpty={rows.length === 0}
+            />
+            <ul>
+              {rows.map((row) => (
+                <NotificationRow
+                  key={row.item.id}
+                  item={row.item}
+                  state={row.state}
+                  onActivate={() => {
+                    if (row.state !== "read") center.markRead(row.item.id);
+                    onClose();
+                  }}
+                  onMarkRead={() => center.markRead(row.item.id)}
+                />
+              ))}
+            </ul>
+          </div>
+
+          {center.hasNextPage ? (
+            <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
+              <Button
+                variant="ghost"
+                size="block"
+                isLoading={center.isFetchingNextPage}
+                onClick={center.fetchNextPage}
+              >
+                {t("panel.showOlder")}
+              </Button>
+            </footer>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+interface FilterSegmentProps {
+  filter: FeedFilter;
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+/** One segment of the track: the chosen one lifts onto the surface rather than filling with hue. */
+function FilterSegment({ filter, label, selected, onSelect }: FilterSegmentProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      data-filter={filter}
+      aria-checked={selected}
+      tabIndex={selected ? 0 : -1}
+      onClick={onSelect}
+      className={cn(
+        // One weight in both states: a segment that thickens when chosen shifts the track's
+        // widths under the pointer, and the fill already says which one is on.
+        "cursor-pointer rounded-[var(--radius-sm)] border px-2.5 py-1 text-[12px] font-medium leading-none transition-colors duration-[var(--motion-fast)] ease-[var(--motion-easing)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--color-primary)]",
+        selected
+          ? "border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-primary)]"
+          : "border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text)]",
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/features/notification/ui/notification-flat.tsx
+++ b/src/features/notification/ui/notification-flat.tsx
@@ -5,12 +5,12 @@ import { usePreferencesStore } from "@/shared/config";
 import { getDirection } from "@/shared/i18n";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { nextRovingChoice } from "../lib/roving-choice";
-import { useNotificationCenter } from "../lib/use-notification-center";
+import { focusRovingChoice, nextRovingChoice } from "../lib/roving-choice";
 import { useOverlayDismiss } from "../lib/use-overlay-dismiss";
 import type { NotificationShapeProps } from "../model/notification-shape";
 import { NotificationFeedStatus } from "./notification-feed-status";
 import { NotificationLifecycleAlert } from "./notification-lifecycle-alert";
+import { NotificationOlderFooter } from "./notification-older-footer";
 import { NotificationRow } from "./notification-row";
 import { NotificationStylePicker } from "./notification-style-picker";
 
@@ -21,6 +21,7 @@ type FeedFilter = (typeof FEED_FILTERS)[number];
 /** The compact list: newest first, no day headings, and a filter for the unread pile. */
 export function NotificationFlat({
   open,
+  center,
   overlayId,
   overlayRef,
   triggerRef,
@@ -30,7 +31,6 @@ export function NotificationFlat({
 }: NotificationShapeProps) {
   const { t } = useTranslation("notification", { useSuspense: false });
   const locale = usePreferencesStore((preferences) => preferences.locale);
-  const center = useNotificationCenter(open);
   const [filter, setFilter] = useState<FeedFilter>("all");
   const filtersRef = useRef<HTMLDivElement>(null);
 
@@ -42,7 +42,7 @@ export function NotificationFlat({
 
     event.preventDefault();
     setFilter(next);
-    filtersRef.current?.querySelector<HTMLButtonElement>(`[data-filter="${next}"]`)?.focus();
+    focusRovingChoice(filtersRef.current, next);
   }
 
   const rows =
@@ -126,7 +126,7 @@ export function NotificationFlat({
                   item={row.item}
                   state={row.state}
                   onActivate={() => {
-                    if (row.state !== "read") center.markRead(row.item.id);
+                    center.activate(row);
                     onClose();
                   }}
                   onMarkRead={() => center.markRead(row.item.id)}
@@ -135,18 +135,7 @@ export function NotificationFlat({
             </ul>
           </div>
 
-          {center.hasNextPage ? (
-            <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
-              <Button
-                variant="ghost"
-                size="block"
-                isLoading={center.isFetchingNextPage}
-                onClick={center.fetchNextPage}
-              >
-                {t("panel.showOlder")}
-              </Button>
-            </footer>
-          ) : null}
+          <NotificationOlderFooter center={center} />
         </>
       )}
     </div>
@@ -166,7 +155,7 @@ function FilterSegment({ filter, label, selected, onSelect }: FilterSegmentProps
     <button
       type="button"
       role="radio"
-      data-filter={filter}
+      data-choice={filter}
       aria-checked={selected}
       tabIndex={selected ? 0 : -1}
       onClick={onSelect}

--- a/src/features/notification/ui/notification-lifecycle-alert.tsx
+++ b/src/features/notification/ui/notification-lifecycle-alert.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+
+interface NotificationLifecycleAlertProps {
+  failed: boolean;
+}
+
+/** A seen, read, or mark-all write that did not land, said once wherever the reader is looking. */
+export function NotificationLifecycleAlert({ failed }: NotificationLifecycleAlertProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+
+  if (!failed) {
+    return null;
+  }
+
+  return (
+    <p
+      role="alert"
+      className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-danger-soft)] px-4 py-2 text-xs text-[var(--color-danger)]"
+    >
+      {t("panel.actionError")}
+    </p>
+  );
+}

--- a/src/features/notification/ui/notification-older-footer.tsx
+++ b/src/features/notification/ui/notification-older-footer.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from "react-i18next";
+import { Button } from "@/shared/ui/button";
+import type { NotificationCenter } from "../lib/use-notification-center";
+
+interface NotificationOlderFooterProps {
+  center: NotificationCenter;
+}
+
+/** The next page of the feed, offered only while there is one — the same footer in every shape. */
+export function NotificationOlderFooter({ center }: NotificationOlderFooterProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+
+  if (!center.hasNextPage) {
+    return null;
+  }
+
+  return (
+    <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
+      <Button
+        variant="ghost"
+        size="block"
+        isLoading={center.isFetchingNextPage}
+        onClick={center.fetchNextPage}
+      >
+        {t("panel.showOlder")}
+      </Button>
+    </footer>
+  );
+}

--- a/src/features/notification/ui/notification-panel.tsx
+++ b/src/features/notification/ui/notification-panel.tsx
@@ -2,17 +2,18 @@ import { Settings2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { useNotificationCenter } from "../lib/use-notification-center";
 import { useOverlayDismiss } from "../lib/use-overlay-dismiss";
 import type { NotificationShapeProps } from "../model/notification-shape";
 import { NotificationBucketList } from "./notification-bucket-list";
 import { NotificationFeedStatus } from "./notification-feed-status";
 import { NotificationLifecycleAlert } from "./notification-lifecycle-alert";
+import { NotificationOlderFooter } from "./notification-older-footer";
 import { NotificationStylePicker } from "./notification-style-picker";
 
 /** The anchored dropdown: the notification center for a quick glance without leaving the page. */
 export function NotificationPanel({
   open,
+  center,
   overlayId,
   overlayRef,
   triggerRef,
@@ -21,7 +22,6 @@ export function NotificationPanel({
   onViewChange,
 }: NotificationShapeProps) {
   const { t } = useTranslation("notification", { useSuspense: false });
-  const center = useNotificationCenter(open);
 
   useOverlayDismiss({ open, overlayRef, triggerRef, onClose });
 
@@ -88,24 +88,13 @@ export function NotificationPanel({
             <NotificationBucketList
               rows={center.rows}
               onActivate={(row) => {
-                if (row.state !== "read") center.markRead(row.item.id);
+                center.activate(row);
                 onClose();
               }}
             />
           </div>
 
-          {center.hasNextPage ? (
-            <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
-              <Button
-                variant="ghost"
-                size="block"
-                isLoading={center.isFetchingNextPage}
-                onClick={center.fetchNextPage}
-              >
-                {t("panel.showOlder")}
-              </Button>
-            </footer>
-          ) : null}
+          <NotificationOlderFooter center={center} />
         </>
       )}
     </div>

--- a/src/features/notification/ui/notification-panel.tsx
+++ b/src/features/notification/ui/notification-panel.tsx
@@ -1,77 +1,34 @@
-import { BellOff } from "lucide-react";
-import { type RefObject, useEffect, useRef } from "react";
+import { Settings2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import type { NotificationFeedItem } from "../api/notification-feed";
-import { useNotificationFeed } from "../api/notification-feed";
-import {
-  SEEN_BATCH_LIMIT,
-  useMarkAllNotificationsRead,
-  useMarkNotificationRead,
-  useMarkNotificationsSeen,
-} from "../api/notification-lifecycle";
-import { NOTIFICATION_CATALOG } from "../model/notification-catalog";
-import {
-  type NotificationRowState,
-  notificationRowState,
-  useBulkReadCursor,
-} from "../model/notification-read-state";
-import { RECENCY_BUCKETS, type RecencyBucket, recencyBucketOf } from "../model/recency-bucket";
-import { NotificationRow } from "./notification-row";
+import { useNotificationCenter } from "../lib/use-notification-center";
+import { useOverlayDismiss } from "../lib/use-overlay-dismiss";
+import type { NotificationShapeProps } from "../model/notification-shape";
+import { NotificationBucketList } from "./notification-bucket-list";
+import { NotificationFeedStatus } from "./notification-feed-status";
+import { NotificationLifecycleAlert } from "./notification-lifecycle-alert";
+import { NotificationStylePicker } from "./notification-style-picker";
 
-interface NotificationPanelProps {
-  open: boolean;
-  panelId: string;
-  panelRef: RefObject<HTMLDivElement | null>;
-  onClose: () => void;
-}
-
-interface NotificationRowModel {
-  readonly item: NotificationFeedItem;
-  readonly state: NotificationRowState;
-}
-
-export function NotificationPanel({ open, panelId, panelRef, onClose }: NotificationPanelProps) {
+/** The anchored dropdown: the notification center for a quick glance without leaving the page. */
+export function NotificationPanel({
+  open,
+  overlayId,
+  overlayRef,
+  triggerRef,
+  view,
+  onClose,
+  onViewChange,
+}: NotificationShapeProps) {
   const { t } = useTranslation("notification", { useSuspense: false });
-  const { data, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage } =
-    useNotificationFeed(open);
-  const bulkReadCursorAt = useBulkReadCursor((cursor) => cursor.cursorAt);
-  const markSeen = useMarkNotificationsSeen();
-  const markRead = useMarkNotificationRead();
-  const markAllRead = useMarkAllNotificationsRead();
+  const center = useNotificationCenter(open);
 
-  // A type the mirror does not know cannot be rendered, and must not leave an empty bucket behind.
-  const rows: NotificationRowModel[] = (data ?? [])
-    .filter((item) => NOTIFICATION_CATALOG.has(item.typeKey))
-    .map((item) => ({ item, state: notificationRowState(item, bulkReadCursorAt) }));
-
-  const hasUnread = rows.some((row) => row.state !== "read");
-  const lifecycleFailed = markSeen.isError || markRead.isError || markAllRead.isError;
-  const unseenIds = rows.filter((row) => row.state === "unseen").map((row) => row.item.id);
-  const unseenKey = unseenIds.join(",");
-  const seenSent = useRef(false);
-
-  useEffect(() => {
-    if (!open) {
-      seenSent.current = false;
-      return;
-    }
-
-    if (seenSent.current || unseenIds.length === 0) return;
-
-    // Reopening with nothing unseen left never reaches this point, which is what keeps the
-    // contract at one request per open rather than one per render.
-    seenSent.current = true;
-    markSeen.mutate(unseenIds.slice(0, SEEN_BATCH_LIMIT));
-    // Keyed on the id list rather than the feed object: the rows re-render far more often than
-    // their identities change, and only a changed identity can owe a request.
-  }, [open, unseenKey]);
+  useOverlayDismiss({ open, overlayRef, triggerRef, onClose });
 
   return (
     <div
-      ref={panelRef}
-      id={panelId}
+      ref={overlayRef}
+      id={overlayId}
       role="dialog"
       aria-label={t("panel.title")}
       tabIndex={-1}
@@ -86,133 +43,71 @@ export function NotificationPanel({ open, panelId, panelRef, onClose }: Notifica
           : "pointer-events-none invisible -translate-y-1 scale-[0.98] opacity-0 duration-[var(--motion-fast)]",
       )}
     >
-      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--color-border)] px-4 py-3">
-        <h2 className="text-sm font-semibold tracking-tight text-[var(--color-text)]">
-          {t("panel.title")}
-        </h2>
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={!hasUnread}
-          isLoading={markAllRead.isPending}
-          onClick={() =>
-            markAllRead.mutate(undefined, {
-              // The affordance disables itself once the feed is clear, so focus is handed back
-              // to the dialog rather than left on a button that has left the tab order.
-              onSuccess: () => panelRef.current?.focus(),
-            })
-          }
-        >
-          {t("panel.markAllRead")}
-        </Button>
-      </header>
+      {view === "settings" ? (
+        <NotificationStylePicker onBack={() => onViewChange("feed")} />
+      ) : (
+        <>
+          <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--color-border)] px-4 py-3">
+            <h2 className="text-sm font-semibold tracking-tight text-[var(--color-text)]">
+              {t("panel.title")}
+            </h2>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={!center.hasUnread}
+                isLoading={center.isMarkingAllRead}
+                onClick={() =>
+                  // The affordance disables itself once the feed is clear, so focus is handed
+                  // back to the dialog rather than left on a button that has left the tab order.
+                  center.markAllRead(() => overlayRef.current?.focus())
+                }
+              >
+                {t("panel.markAllRead")}
+              </Button>
+              <Button
+                intent="toggle"
+                size="iconXs"
+                title={t("picker.open")}
+                aria-label={t("picker.open")}
+                onClick={() => onViewChange("settings")}
+                leadingIcon={<Settings2 size={14} />}
+                iconOnly
+              />
+            </div>
+          </header>
 
-      {lifecycleFailed ? (
-        <p
-          role="alert"
-          className="shrink-0 border-b border-[var(--color-border)] bg-[var(--color-danger-soft)] px-4 py-2 text-xs text-[var(--color-danger)]"
-        >
-          {t("panel.actionError")}
-        </p>
-      ) : null}
+          <NotificationLifecycleAlert failed={center.lifecycleFailed} />
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        {isPending ? <PanelMessage>{t("panel.loading")}</PanelMessage> : null}
-        {isError ? <PanelMessage>{t("panel.error")}</PanelMessage> : null}
-        {!isPending && !isError && rows.length === 0 ? (
-          <EmptyFeed title={t("panel.empty.title")} hint={t("panel.empty.hint")} />
-        ) : null}
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <NotificationFeedStatus
+              isPending={center.isPending}
+              isError={center.isError}
+              isEmpty={center.rows.length === 0}
+            />
+            <NotificationBucketList
+              rows={center.rows}
+              onActivate={(row) => {
+                if (row.state !== "read") center.markRead(row.item.id);
+                onClose();
+              }}
+            />
+          </div>
 
-        {RECENCY_BUCKETS.map((bucket) => (
-          <BucketSection
-            key={bucket}
-            bucket={bucket}
-            label={t(`panel.buckets.${bucket}`)}
-            rows={rows.filter((row) => recencyBucketOf(row.item.createdAt) === bucket)}
-            onActivate={(row) => {
-              if (row.state !== "read") markRead.mutate(row.item.id);
-              onClose();
-            }}
-          />
-        ))}
-      </div>
-
-      {hasNextPage ? (
-        <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
-          <Button
-            variant="ghost"
-            size="block"
-            isLoading={isFetchingNextPage}
-            onClick={() => void fetchNextPage()}
-          >
-            {t("panel.showOlder")}
-          </Button>
-        </footer>
-      ) : null}
-    </div>
-  );
-}
-
-interface BucketSectionProps {
-  bucket: RecencyBucket;
-  label: string;
-  rows: NotificationRowModel[];
-  onActivate: (row: NotificationRowModel) => void;
-}
-
-function BucketSection({ bucket, label, rows, onActivate }: BucketSectionProps) {
-  if (rows.length === 0) {
-    return null;
-  }
-
-  return (
-    <section aria-labelledby={`notification-bucket-${bucket}`}>
-      <h3
-        id={`notification-bucket-${bucket}`}
-        className="sticky top-0 bg-[var(--color-surface)] px-4 pb-1 pt-3 text-[11px] font-semibold uppercase tracking-widest text-[var(--color-text-faint)]"
-      >
-        {label}
-      </h3>
-      <ul>
-        {rows.map((row) => (
-          <NotificationRow
-            key={row.item.id}
-            item={row.item}
-            state={row.state}
-            onActivate={() => onActivate(row)}
-          />
-        ))}
-      </ul>
-    </section>
-  );
-}
-
-interface PanelMessageProps {
-  children: string;
-}
-
-function PanelMessage({ children }: PanelMessageProps) {
-  return (
-    <p className="px-4 py-8 text-center text-[13px] text-[var(--color-text-muted)]">{children}</p>
-  );
-}
-
-interface EmptyFeedProps {
-  title: string;
-  hint: string;
-}
-
-function EmptyFeed({ title, hint }: EmptyFeedProps) {
-  return (
-    <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
-      <span
-        aria-hidden="true"
-        className="flex size-9 items-center justify-center rounded-full bg-[var(--color-surface-2)] text-[var(--color-text-faint)]"
-      >
-        <BellOff size={16} />
-      </span>
-      <p className="text-[13px] font-medium text-[var(--color-text)]">{title}</p>
-      <p className="max-w-[240px] text-xs leading-relaxed text-[var(--color-text-faint)]">{hint}</p>
+          {center.hasNextPage ? (
+            <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
+              <Button
+                variant="ghost"
+                size="block"
+                isLoading={center.isFetchingNextPage}
+                onClick={center.fetchNextPage}
+              >
+                {t("panel.showOlder")}
+              </Button>
+            </footer>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/src/features/notification/ui/notification-row.test.tsx
+++ b/src/features/notification/ui/notification-row.test.tsx
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import i18next from "i18next";
+import { act } from "react";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { NotificationFeedItem } from "../api/notification-feed";
+import { NotificationRow } from "./notification-row";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+const testI18n = i18next.createInstance();
+
+const LEAD_TITLE = "New lead registered";
+const LEAD_BODY = "A new lead joined the pipeline and is ready for review.";
+
+/** Where the row's text block sits in the window, so "above" and "below" are tellable apart. */
+const TEXT_BLOCK = { top: 300, bottom: 340, left: 40, right: 340, width: 300, height: 40 };
+
+const leadRow: NotificationFeedItem = {
+  id: 1,
+  scope: "platform",
+  typeKey: "platform.lead-created",
+  typeVersion: 1,
+  importance: "normal",
+  params: {},
+  actor: { kind: "system" },
+  subject: { type: "lead", publicId: "lead-1" },
+  createdAt: new Date().toISOString(),
+  seenAt: null,
+  readAt: null,
+};
+
+/**
+ * jsdom performs no layout, so every element reports zero width and an empty rect. Overriding
+ * what the tooltip reads is what lets a test say "this line did not fit" and "it opened here".
+ */
+function withMeasurements(scrollWidth: number, clientWidth: number) {
+  for (const [property, value] of [
+    ["scrollWidth", scrollWidth],
+    ["clientWidth", clientWidth],
+  ] as const) {
+    Object.defineProperty(HTMLElement.prototype, property, { configurable: true, value });
+  }
+
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      ...TEXT_BLOCK,
+      x: TEXT_BLOCK.left,
+      y: TEXT_BLOCK.top,
+      toJSON: () => TEXT_BLOCK,
+    }),
+  });
+}
+
+function renderRow() {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <ul>
+        <NotificationRow item={leadRow} state="settled" onActivate={vi.fn()} />
+      </ul>
+    </I18nextProvider>,
+  );
+}
+
+/** The tooltip waits out a pointer passing through before it opens. */
+function hover(element: HTMLElement) {
+  fireEvent.pointerEnter(element);
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
+}
+
+describe("NotificationRow", () => {
+  beforeAll(async () => {
+    await testI18n.init({
+      lng: "en",
+      fallbackLng: "en",
+      ns: ["notification"],
+      defaultNS: "notification",
+      keySeparator: false,
+      interpolation: { escapeValue: false },
+      resources: {
+        en: {
+          notification: JSON.parse(readFileSync("public/locales/en/notification.json", "utf8")),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    for (const property of ["scrollWidth", "clientWidth"]) {
+      Object.defineProperty(HTMLElement.prototype, property, { configurable: true, value: 0 });
+    }
+  });
+
+  it("shows the whole notification on hover when the row clipped it", () => {
+    vi.useFakeTimers();
+    withMeasurements(420, 200);
+    renderRow();
+
+    hover(screen.getByText(LEAD_TITLE).parentElement as HTMLElement);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent(LEAD_TITLE);
+    expect(tooltip).toHaveTextContent(LEAD_BODY);
+  });
+
+  it("opens the tooltip below the notification, never over it", () => {
+    vi.useFakeTimers();
+    withMeasurements(420, 200);
+    renderRow();
+
+    hover(screen.getByText(LEAD_TITLE).parentElement as HTMLElement);
+
+    expect(screen.getByRole("tooltip")).toHaveStyle({ top: `${TEXT_BLOCK.bottom + 6}px` });
+  });
+
+  it("stays silent when the whole notification is already on screen", () => {
+    vi.useFakeTimers();
+    withMeasurements(200, 200);
+    renderRow();
+
+    hover(screen.getByText(LEAD_TITLE).parentElement as HTMLElement);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("puts the notification away again when the pointer leaves", () => {
+    vi.useFakeTimers();
+    withMeasurements(420, 200);
+    renderRow();
+
+    const trigger = screen.getByText(LEAD_TITLE).parentElement as HTMLElement;
+    hover(trigger);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    fireEvent.pointerLeave(trigger);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/notification/ui/notification-row.tsx
+++ b/src/features/notification/ui/notification-row.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
+import { Check } from "lucide-react";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { usePreferencesStore } from "@/shared/config";
@@ -21,7 +22,16 @@ const toneClassName: Record<NotificationTone, string> = {
   warning: "bg-[var(--color-warning-soft)] text-[var(--color-warning)]",
 };
 
-const rowClassName = "flex w-full items-start gap-2.5 px-4 py-2.5 text-start";
+const rowClassName = "flex w-full items-start gap-2.5 text-start";
+
+/** How much air a row takes: the dropdowns stay compact, the sheet reads as a triage list. */
+const densityClassName = {
+  compact: "px-4 py-2.5",
+  roomy: "px-5 py-3.5",
+} as const;
+
+/** Room at the inline end for the mark-read control, so it never sits on top of the time. */
+const markReadRowClassName = "pe-11";
 
 /** The whole unseen-to-read visual arc in one table: wash, tile, title, body. */
 const stateClassName: Record<
@@ -53,9 +63,22 @@ interface NotificationRowProps {
   state: NotificationRowState;
   /** Marks the row read and closes the panel; only clickable rows can reach it. */
   onActivate: () => void;
+  /**
+   * Marks this row read on its own, without opening it. Absent in the panel, where a row is
+   * read by activation alone; present in the shapes built for triage, which is also the only
+   * individual read path a row with nowhere to navigate has.
+   */
+  onMarkRead?: () => void;
+  density?: keyof typeof densityClassName;
 }
 
-export function NotificationRow({ item, state, onActivate }: NotificationRowProps) {
+export function NotificationRow({
+  item,
+  state,
+  onActivate,
+  onMarkRead,
+  density = "compact",
+}: NotificationRowProps) {
   const { t } = useTranslation("notification", { useSuspense: false });
   const locale = usePreferencesStore((preferences) => preferences.locale);
   const navigate = useNavigate();
@@ -126,12 +149,25 @@ export function NotificationRow({ item, state, onActivate }: NotificationRowProp
     </>
   );
 
+  // Only an unread row has anything to mark, and the control is a sibling of the row button
+  // rather than a child of it, because a button cannot hold another button.
+  const markRead =
+    onMarkRead && state !== "read" ? (
+      <MarkReadControl label={t("row.markRead")} onMarkRead={onMarkRead} />
+    ) : null;
+  const rowPadding = cn(densityClassName[density], markRead && markReadRowClassName);
+
   if (!route) {
-    return <li className={cn(rowClassName, presentation.row)}>{content}</li>;
+    return (
+      <li className={cn("group relative", presentation.row)}>
+        <div className={cn(rowClassName, rowPadding)}>{content}</div>
+        {markRead}
+      </li>
+    );
   }
 
   return (
-    <li className={presentation.row}>
+    <li className={cn("group relative", presentation.row)}>
       <button
         type="button"
         onClick={() => {
@@ -140,12 +176,37 @@ export function NotificationRow({ item, state, onActivate }: NotificationRowProp
         }}
         className={cn(
           rowClassName,
+          rowPadding,
           "cursor-pointer transition-colors duration-[var(--motion-fast)] ease-[var(--motion-easing)] hover:bg-[var(--color-surface-2)] focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-[var(--color-primary)]",
         )}
       >
         {content}
       </button>
+      {markRead}
     </li>
+  );
+}
+
+interface MarkReadControlProps {
+  label: string;
+  onMarkRead: () => void;
+}
+
+/**
+ * Quiet until wanted: the control is always in the tab order and announced, and only its
+ * opacity waits for a pointer or focus to arrive.
+ */
+function MarkReadControl({ label, onMarkRead }: MarkReadControlProps) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      onClick={onMarkRead}
+      className="absolute end-2 top-1/2 flex size-7 cursor-pointer -translate-y-1/2 items-center justify-center rounded-[var(--radius-md)] border border-transparent text-[var(--color-text-faint)] opacity-0 transition-[opacity,color,background-color,border-color] duration-[var(--motion-fast)] ease-[var(--motion-easing)] hover:border-[var(--color-border)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] group-hover:opacity-100 group-focus-within:opacity-100"
+    >
+      <Check size={14} aria-hidden="true" />
+    </button>
   );
 }
 

--- a/src/features/notification/ui/notification-row.tsx
+++ b/src/features/notification/ui/notification-row.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { usePreferencesStore } from "@/shared/config";
 import { cn } from "@/shared/lib/cn";
 import { useClippedText } from "@/shared/lib/use-clipped-text";
+import { Button } from "@/shared/ui/button";
 import { Tooltip } from "@/shared/ui/tooltip";
 import type { NotificationFeedItem } from "../api/notification-feed";
 import { formatRelativeTime } from "../lib/relative-time";
@@ -25,10 +26,12 @@ const toneClassName: Record<NotificationTone, string> = {
 const rowClassName = "flex w-full items-start gap-2.5 text-start";
 
 /** How much air a row takes: the dropdowns stay compact, the sheet reads as a triage list. */
-const densityClassName = {
+export type NotificationRowDensity = "compact" | "roomy";
+
+const densityClassName: Record<NotificationRowDensity, string> = {
   compact: "px-4 py-2.5",
   roomy: "px-5 py-3.5",
-} as const;
+};
 
 /** Room at the inline end for the mark-read control, so it never sits on top of the time. */
 const markReadRowClassName = "pe-11";
@@ -69,7 +72,7 @@ interface NotificationRowProps {
    * individual read path a row with nowhere to navigate has.
    */
   onMarkRead?: () => void;
-  density?: keyof typeof densityClassName;
+  density?: NotificationRowDensity;
 }
 
 export function NotificationRow({
@@ -198,15 +201,16 @@ interface MarkReadControlProps {
  */
 function MarkReadControl({ label, onMarkRead }: MarkReadControlProps) {
   return (
-    <button
-      type="button"
+    <Button
+      intent="toggle"
+      size="iconXs"
       title={label}
       aria-label={label}
       onClick={onMarkRead}
-      className="absolute end-2 top-1/2 flex size-7 cursor-pointer -translate-y-1/2 items-center justify-center rounded-[var(--radius-md)] border border-transparent text-[var(--color-text-faint)] opacity-0 transition-[opacity,color,background-color,border-color] duration-[var(--motion-fast)] ease-[var(--motion-easing)] hover:border-[var(--color-border)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)] group-hover:opacity-100 group-focus-within:opacity-100"
-    >
-      <Check size={14} aria-hidden="true" />
-    </button>
+      leadingIcon={<Check size={14} />}
+      iconOnly
+      className="absolute end-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity duration-[var(--motion-fast)] ease-[var(--motion-easing)] focus-visible:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100"
+    />
   );
 }
 

--- a/src/features/notification/ui/notification-row.tsx
+++ b/src/features/notification/ui/notification-row.tsx
@@ -1,7 +1,10 @@
 import { useNavigate } from "@tanstack/react-router";
+import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { usePreferencesStore } from "@/shared/config";
 import { cn } from "@/shared/lib/cn";
+import { useClippedText } from "@/shared/lib/use-clipped-text";
+import { Tooltip } from "@/shared/ui/tooltip";
 import type { NotificationFeedItem } from "../api/notification-feed";
 import { formatRelativeTime } from "../lib/relative-time";
 import {
@@ -56,9 +59,13 @@ export function NotificationRow({ item, state, onActivate }: NotificationRowProp
   const { t } = useTranslation("notification", { useSuspense: false });
   const locale = usePreferencesStore((preferences) => preferences.locale);
   const navigate = useNavigate();
+  const titleRef = useRef<HTMLSpanElement>(null);
+  const bodyRef = useRef<HTMLSpanElement>(null);
 
   const entry = NOTIFICATION_CATALOG.get(item.typeKey);
   const copy = resolveNotificationCopy(item, t, locale);
+  const titleClipped = useClippedText(titleRef, copy?.title ?? "");
+  const bodyClipped = useClippedText(bodyRef, copy?.body ?? "");
 
   if (!entry || !copy) {
     return null;
@@ -86,16 +93,30 @@ export function NotificationRow({ item, state, onActivate }: NotificationRowProp
       >
         <Icon size={14} />
       </span>
-      <span className="min-w-0 flex-1">
+      <Tooltip
+        content={
+          <span className="block">
+            <span className="block font-semibold">{copy.title}</span>
+            <span className="mt-0.5 block font-normal">{copy.body}</span>
+          </span>
+        }
+        disabled={!titleClipped && !bodyClipped}
+        placement="below"
+        className="min-w-0 flex-1"
+      >
         <span
+          ref={titleRef}
           className={cn("block truncate text-[13px] font-medium leading-snug", presentation.title)}
         >
           {copy.title}
         </span>
-        <span className={cn("mt-0.5 block truncate text-xs leading-snug", presentation.body)}>
+        <span
+          ref={bodyRef}
+          className={cn("mt-0.5 block truncate text-xs leading-snug", presentation.body)}
+        >
           {copy.body}
         </span>
-      </span>
+      </Tooltip>
       <time
         dateTime={item.createdAt}
         className="shrink-0 pt-0.5 text-[11px] tabular-nums text-[var(--color-text-faint)]"

--- a/src/features/notification/ui/notification-shapes.test.tsx
+++ b/src/features/notification/ui/notification-shapes.test.tsx
@@ -1,0 +1,302 @@
+import { readFileSync } from "node:fs";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import i18next from "i18next";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthSession, SessionUser } from "@/shared/auth";
+import { useAuthStore } from "@/shared/auth";
+import { type NotificationListStyle, usePreferencesStore } from "@/shared/config";
+import type { NotificationFeedItem } from "../api/notification-feed";
+import { useBulkReadCursor } from "../model/notification-read-state";
+import { NotificationBell } from "./notification-bell";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const apiGetMock = vi.hoisted(() => vi.fn());
+const apiPostMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => navigateMock,
+}));
+
+// `ky` builds AbortSignals that jsdom's fetch rejects as cross-realm — stub the client boundary
+// instead of the network.
+vi.mock("@/shared/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api")>()),
+  apiClient: { get: apiGetMock, post: apiPostMock },
+}));
+
+const testI18n = i18next.createInstance();
+
+const baseUser: SessionUser = {
+  publicId: "user-1",
+  employeeCode: "EMP-001",
+  firstName: "Jane",
+  lastName: "Doe",
+  email: "jane@example.com",
+  status: "ACTIVE",
+  companyCode: "ACME",
+  mustChangePassword: false,
+  permissions: [],
+  isOwner: false,
+  isPlatformAdmin: false,
+};
+
+const session: AuthSession = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  sessionId: "session-1",
+  expiresIn: 900,
+  user: baseUser,
+};
+
+/**
+ * A fixed midday "now": the recency buckets are calendar days, so a suite that reads the real
+ * clock puts its rows in different buckets when it runs a few minutes either side of midnight.
+ */
+const now = new Date("2026-08-25T12:00:00Z");
+const hoursAgo = (hours: number) => new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
+
+const unreadRow: NotificationFeedItem = {
+  id: 1,
+  scope: "platform",
+  typeKey: "platform.lead-created",
+  typeVersion: 1,
+  importance: "normal",
+  params: {},
+  actor: { kind: "system" },
+  subject: { type: "lead", publicId: "lead-1" },
+  createdAt: hoursAgo(1),
+  seenAt: null,
+  readAt: null,
+};
+
+/** Already read, so it is the row the Unread chip has to hide. */
+const readRow: NotificationFeedItem = {
+  ...unreadRow,
+  id: 2,
+  typeKey: "company.user-joined",
+  subject: null,
+  createdAt: hoursAgo(30),
+  seenAt: hoursAgo(29),
+  readAt: hoursAgo(29),
+};
+
+function stubEndpoints({ unreadCount = 0, items = [] as NotificationFeedItem[] } = {}) {
+  apiGetMock.mockImplementation((path: string) => {
+    if (path.endsWith("unread-count")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ unreadCount }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+
+    return { json: async () => ({ items, nextCursor: null, hasMore: false }) };
+  });
+
+  apiPostMock.mockResolvedValue(new Response(null, { status: 204 }));
+}
+
+function renderBell(listStyle: NotificationListStyle) {
+  usePreferencesStore.setState({ notificationListStyle: listStyle });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>
+        <NotificationBell />
+      </QueryClientProvider>
+    </I18nextProvider>,
+  );
+}
+
+async function openCenter(listStyle: NotificationListStyle) {
+  renderBell(listStyle);
+  const bell = await screen.findByRole("button", { name: /Notifications/ });
+  fireEvent.click(bell);
+  return bell;
+}
+
+beforeAll(async () => {
+  await testI18n.init({
+    lng: "en",
+    fallbackLng: "en",
+    ns: ["notification"],
+    defaultNS: "notification",
+    keySeparator: false,
+    interpolation: { escapeValue: false },
+    resources: {
+      en: {
+        notification: JSON.parse(readFileSync("public/locales/en/notification.json", "utf8")),
+      },
+    },
+  });
+});
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"], now, shouldAdvanceTime: true });
+  useAuthStore.setState({ session, status: "authenticated" });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+  vi.clearAllMocks();
+  useBulkReadCursor.setState({ cursorAt: null });
+  useAuthStore.setState({ session: null, status: "anonymous" });
+  usePreferencesStore.setState({ notificationListStyle: "panel" });
+  localStorage.removeItem("hrms-prefs");
+});
+
+describe("notification list shapes", () => {
+  it("opens the sheet, holds the page still behind it, and lets it go on Escape", async () => {
+    stubEndpoints({ items: [unreadRow] });
+    const bell = await openCenter("sheet");
+
+    const sheet = await screen.findByRole("dialog", { name: "Notifications" });
+    expect(sheet).toHaveAttribute("aria-modal", "true");
+    expect(await screen.findByText("New lead registered")).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(document.body.style.overflow).toBe(""));
+    expect(bell).toHaveFocus();
+  });
+
+  it("keeps the sheet's day headings and closes it from its own close control", async () => {
+    stubEndpoints({ items: [unreadRow, readRow] });
+    await openCenter("sheet");
+
+    expect(await screen.findByRole("heading", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Yesterday" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close notifications" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Notifications/ })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      ),
+    );
+  });
+
+  it("reads one row from its own control without opening it", async () => {
+    stubEndpoints({ unreadCount: 1, items: [unreadRow] });
+    await openCenter("sheet");
+    await screen.findByText("New lead registered");
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark as read" }));
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith("company/notifications/read", { json: { id: 1 } }),
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("gives a row with nowhere to navigate its own read path, reachable by keyboard", async () => {
+    stubEndpoints({ items: [{ ...readRow, readAt: null, seenAt: hoursAgo(29) }] });
+    await openCenter("sheet");
+    await screen.findByText("New member joined");
+
+    const markRead = screen.getByRole("button", { name: "Mark as read" });
+    markRead.focus();
+    expect(markRead).toHaveFocus();
+    fireEvent.click(markRead);
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith("company/notifications/read", { json: { id: 2 } }),
+    );
+  });
+
+  it("filters the compact list to unread rows without touching the badge", async () => {
+    stubEndpoints({ unreadCount: 1, items: [unreadRow, readRow] });
+    await openCenter("flat");
+
+    expect(await screen.findByText("New lead registered")).toBeInTheDocument();
+    expect(screen.getByText("New member joined")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Today" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Unread" }));
+
+    expect(screen.queryByText("New member joined")).not.toBeInTheDocument();
+    expect(screen.getByText("New lead registered")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Unread" })).toHaveAttribute("aria-checked", "true");
+    expect(await screen.findByRole("button", { name: "Notifications, 1 unread" })).toBeVisible();
+  });
+
+  it("marks everything read from the compact list's icon control", async () => {
+    stubEndpoints({ unreadCount: 1, items: [unreadRow] });
+    await openCenter("flat");
+    await screen.findByText("New lead registered");
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark all read" }));
+
+    await waitFor(() =>
+      expect(apiPostMock).toHaveBeenCalledWith("company/notifications/read", {
+        json: { all: true },
+      }),
+    );
+  });
+});
+
+describe("notification style picker", () => {
+  it("swaps the open shape for the new one the moment the reader picks it, and keeps the choice", async () => {
+    stubEndpoints({ items: [unreadRow] });
+    await openCenter("panel");
+    await screen.findByText("New lead registered");
+
+    fireEvent.click(screen.getByRole("button", { name: "Notification settings" }));
+
+    const options = screen.getByRole("radiogroup", { name: "List style" });
+    expect(within(options).getByRole("radio", { name: /Panel/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+
+    fireEvent.click(within(options).getByRole("radio", { name: /Sheet/ }));
+
+    expect(usePreferencesStore.getState().notificationListStyle).toBe("sheet");
+    // The picker rides along into the new shape, so the next option is one click away.
+    expect(await screen.findByRole("dialog", { name: "Notifications" })).toHaveAttribute(
+      "aria-modal",
+      "true",
+    );
+    expect(screen.getByRole("radiogroup", { name: "List style" })).toBeInTheDocument();
+
+    await usePreferencesStore.persist.rehydrate();
+    expect(JSON.parse(localStorage.getItem("hrms-prefs") ?? "{}").state).toMatchObject({
+      notificationListStyle: "sheet",
+    });
+  });
+
+  it("walks the options with the arrow keys", async () => {
+    stubEndpoints({ items: [unreadRow] });
+    await openCenter("panel");
+
+    fireEvent.click(screen.getByRole("button", { name: "Notification settings" }));
+    fireEvent.keyDown(screen.getByRole("radiogroup", { name: "List style" }), { key: "ArrowDown" });
+
+    expect(usePreferencesStore.getState().notificationListStyle).toBe("sheet");
+    // The choice rebuilt the picker inside the sheet, so the option to assert on is the new one.
+    const options = screen.getByRole("radiogroup", { name: "List style" });
+    expect(within(options).getByRole("radio", { name: /Sheet/ })).toHaveFocus();
+  });
+
+  it("returns to the feed from the picker's back control", async () => {
+    stubEndpoints({ items: [unreadRow] });
+    await openCenter("flat");
+    await screen.findByText("New lead registered");
+
+    fireEvent.click(screen.getByRole("button", { name: "Notification settings" }));
+    expect(screen.queryByText("New lead registered")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to notifications" }));
+
+    expect(await screen.findByText("New lead registered")).toBeInTheDocument();
+    expect(screen.queryByRole("radiogroup", { name: "List style" })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/notification/ui/notification-shapes.test.tsx
+++ b/src/features/notification/ui/notification-shapes.test.tsx
@@ -273,17 +273,22 @@ describe("notification style picker", () => {
     });
   });
 
-  it("walks the options with the arrow keys", async () => {
+  it("moves focus with the arrow keys and waits to be told before changing the style", async () => {
     stubEndpoints({ items: [unreadRow] });
     await openCenter("panel");
 
     fireEvent.click(screen.getByRole("button", { name: "Notification settings" }));
-    fireEvent.keyDown(screen.getByRole("radiogroup", { name: "List style" }), { key: "ArrowDown" });
+    const options = screen.getByRole("radiogroup", { name: "List style" });
+    fireEvent.keyDown(options, { key: "ArrowDown" });
+
+    const sheetOption = within(options).getByRole("radio", { name: /Sheet/ });
+    expect(sheetOption).toHaveFocus();
+    expect(sheetOption).toHaveAttribute("aria-checked", "false");
+    expect(usePreferencesStore.getState().notificationListStyle).toBe("panel");
+
+    fireEvent.click(sheetOption);
 
     expect(usePreferencesStore.getState().notificationListStyle).toBe("sheet");
-    // The choice rebuilt the picker inside the sheet, so the option to assert on is the new one.
-    const options = screen.getByRole("radiogroup", { name: "List style" });
-    expect(within(options).getByRole("radio", { name: /Sheet/ })).toHaveFocus();
   });
 
   it("returns to the feed from the picker's back control", async () => {

--- a/src/features/notification/ui/notification-sheet.tsx
+++ b/src/features/notification/ui/notification-sheet.tsx
@@ -3,17 +3,18 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { useBodyScrollLock } from "../lib/use-body-scroll-lock";
-import { useNotificationCenter } from "../lib/use-notification-center";
 import { useOverlayDismiss } from "../lib/use-overlay-dismiss";
 import type { NotificationShapeProps } from "../model/notification-shape";
 import { NotificationBucketList } from "./notification-bucket-list";
 import { NotificationFeedStatus } from "./notification-feed-status";
 import { NotificationLifecycleAlert } from "./notification-lifecycle-alert";
+import { NotificationOlderFooter } from "./notification-older-footer";
 import { NotificationStylePicker } from "./notification-style-picker";
 
 /** The end-side sheet: the notification center as a place to sit and work through the feed. */
 export function NotificationSheet({
   open,
+  center,
   overlayId,
   overlayRef,
   triggerRef,
@@ -22,19 +23,23 @@ export function NotificationSheet({
   onViewChange,
 }: NotificationShapeProps) {
   const { t } = useTranslation("notification", { useSuspense: false });
-  const center = useNotificationCenter(open);
 
   useOverlayDismiss({ open, overlayRef, triggerRef, onClose });
   useBodyScrollLock(open);
 
   return (
     <>
+      {/*
+        Decorative: a pointer landing here is outside the sheet, which is what the shared
+        dismissal already closes on. It also covers the bell, so a click where the bell used
+        to be closes the sheet rather than toggling it — the same thing, by the same rule.
+      */}
       <div
         aria-hidden="true"
         className={cn(
-          "fixed inset-0 z-40 bg-[color-mix(in_srgb,var(--color-text)_32%,transparent)] transition-[opacity,visibility] ease-[var(--motion-easing)]",
+          "fixed inset-0 z-40 cursor-default bg-[var(--color-overlay)] transition-[opacity,visibility] ease-[var(--motion-easing)]",
           open
-            ? "visible opacity-100 duration-[var(--motion-base)]"
+            ? "visible opacity-100 duration-[var(--motion-slow)]"
             : "pointer-events-none invisible opacity-0 duration-[var(--motion-fast)]",
         )}
       />
@@ -52,7 +57,7 @@ export function NotificationSheet({
           // Slides in from the edge it is docked to; exit is shorter than entry.
           "transition-[transform,visibility] ease-[var(--motion-easing)]",
           open
-            ? "visible translate-x-0 duration-[var(--motion-base)]"
+            ? "visible translate-x-0 duration-[var(--motion-slow)]"
             : "invisible duration-[var(--motion-fast)] ltr:translate-x-full rtl:-translate-x-full",
         )}
       >
@@ -110,25 +115,14 @@ export function NotificationSheet({
                 rows={center.rows}
                 density="roomy"
                 onActivate={(row) => {
-                  if (row.state !== "read") center.markRead(row.item.id);
+                  center.activate(row);
                   onClose();
                 }}
                 onMarkRead={(row) => center.markRead(row.item.id)}
               />
             </div>
 
-            {center.hasNextPage ? (
-              <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
-                <Button
-                  variant="ghost"
-                  size="block"
-                  isLoading={center.isFetchingNextPage}
-                  onClick={center.fetchNextPage}
-                >
-                  {t("panel.showOlder")}
-                </Button>
-              </footer>
-            ) : null}
+            <NotificationOlderFooter center={center} />
           </>
         )}
       </div>

--- a/src/features/notification/ui/notification-sheet.tsx
+++ b/src/features/notification/ui/notification-sheet.tsx
@@ -1,0 +1,137 @@
+import { Settings2, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { useBodyScrollLock } from "../lib/use-body-scroll-lock";
+import { useNotificationCenter } from "../lib/use-notification-center";
+import { useOverlayDismiss } from "../lib/use-overlay-dismiss";
+import type { NotificationShapeProps } from "../model/notification-shape";
+import { NotificationBucketList } from "./notification-bucket-list";
+import { NotificationFeedStatus } from "./notification-feed-status";
+import { NotificationLifecycleAlert } from "./notification-lifecycle-alert";
+import { NotificationStylePicker } from "./notification-style-picker";
+
+/** The end-side sheet: the notification center as a place to sit and work through the feed. */
+export function NotificationSheet({
+  open,
+  overlayId,
+  overlayRef,
+  triggerRef,
+  view,
+  onClose,
+  onViewChange,
+}: NotificationShapeProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+  const center = useNotificationCenter(open);
+
+  useOverlayDismiss({ open, overlayRef, triggerRef, onClose });
+  useBodyScrollLock(open);
+
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className={cn(
+          "fixed inset-0 z-40 bg-[color-mix(in_srgb,var(--color-text)_32%,transparent)] transition-[opacity,visibility] ease-[var(--motion-easing)]",
+          open
+            ? "visible opacity-100 duration-[var(--motion-base)]"
+            : "pointer-events-none invisible opacity-0 duration-[var(--motion-fast)]",
+        )}
+      />
+      <div
+        ref={overlayRef}
+        id={overlayId}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("panel.title")}
+        tabIndex={-1}
+        inert={!open}
+        aria-hidden={!open}
+        className={cn(
+          "fixed inset-y-0 end-0 z-50 flex w-[420px] max-w-[calc(100vw-32px)] flex-col overflow-hidden border-s border-[var(--color-border)] bg-[var(--color-surface)] shadow-[var(--shadow-md)] outline-none",
+          // Slides in from the edge it is docked to; exit is shorter than entry.
+          "transition-[transform,visibility] ease-[var(--motion-easing)]",
+          open
+            ? "visible translate-x-0 duration-[var(--motion-base)]"
+            : "invisible duration-[var(--motion-fast)] ltr:translate-x-full rtl:-translate-x-full",
+        )}
+      >
+        {view === "settings" ? (
+          <NotificationStylePicker onBack={() => onViewChange("feed")} />
+        ) : (
+          <>
+            <header className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--color-border)] px-5 py-4">
+              <h2 className="text-sm font-semibold tracking-tight text-[var(--color-text)]">
+                {t("panel.title")}
+              </h2>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={!center.hasUnread}
+                  isLoading={center.isMarkingAllRead}
+                  onClick={() => center.markAllRead(() => overlayRef.current?.focus())}
+                >
+                  {t("panel.markAllRead")}
+                </Button>
+                <Button
+                  intent="toggle"
+                  size="iconXs"
+                  title={t("picker.open")}
+                  aria-label={t("picker.open")}
+                  onClick={() => onViewChange("settings")}
+                  leadingIcon={<Settings2 size={14} />}
+                  iconOnly
+                />
+                <Button
+                  intent="toggle"
+                  size="iconXs"
+                  title={t("sheet.close")}
+                  aria-label={t("sheet.close")}
+                  onClick={() => {
+                    onClose();
+                    triggerRef.current?.focus();
+                  }}
+                  leadingIcon={<X size={14} />}
+                  iconOnly
+                />
+              </div>
+            </header>
+
+            <NotificationLifecycleAlert failed={center.lifecycleFailed} />
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <NotificationFeedStatus
+                isPending={center.isPending}
+                isError={center.isError}
+                isEmpty={center.rows.length === 0}
+              />
+              <NotificationBucketList
+                rows={center.rows}
+                density="roomy"
+                onActivate={(row) => {
+                  if (row.state !== "read") center.markRead(row.item.id);
+                  onClose();
+                }}
+                onMarkRead={(row) => center.markRead(row.item.id)}
+              />
+            </div>
+
+            {center.hasNextPage ? (
+              <footer className="shrink-0 border-t border-[var(--color-border)] p-2">
+                <Button
+                  variant="ghost"
+                  size="block"
+                  isLoading={center.isFetchingNextPage}
+                  onClick={center.fetchNextPage}
+                >
+                  {t("panel.showOlder")}
+                </Button>
+              </footer>
+            ) : null}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/features/notification/ui/notification-style-picker.tsx
+++ b/src/features/notification/ui/notification-style-picker.tsx
@@ -1,0 +1,132 @@
+import { ArrowLeft, ArrowRight, Check } from "lucide-react";
+import { type KeyboardEvent, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { type NotificationListStyle, usePreferencesStore } from "@/shared/config";
+import { getDirection } from "@/shared/i18n";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { nextRovingChoice } from "../lib/roving-choice";
+import { NOTIFICATION_LIST_STYLES } from "../model/notification-list-style";
+import { NotificationStylePreview } from "./notification-style-preview";
+
+interface NotificationStylePickerProps {
+  onBack: () => void;
+}
+
+/** The style choice, shown in place of the feed inside whichever shape is open. */
+export function NotificationStylePicker({ onBack }: NotificationStylePickerProps) {
+  const { t } = useTranslation("notification", { useSuspense: false });
+  const locale = usePreferencesStore((preferences) => preferences.locale);
+  const selected = usePreferencesStore((preferences) => preferences.notificationListStyle);
+  const setStyle = usePreferencesStore((preferences) => preferences.setNotificationListStyle);
+  const optionsRef = useRef<HTMLDivElement>(null);
+
+  const direction = getDirection(locale);
+  const BackIcon = direction === "rtl" ? ArrowRight : ArrowLeft;
+
+  // The picker is remounted by the very choice it applies — the shape around it changes — so
+  // it takes focus back to the chosen option, and arrow keys keep walking where they left off.
+  useEffect(() => {
+    focusOption(optionsRef.current, selected);
+  }, [selected]);
+
+  // Arrow keys walk the group, as they do in any radio group; the buttons themselves carry a
+  // roving tab stop so Tab leaves the group rather than stepping through it.
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    const nextStyle = nextRovingChoice(event.key, direction, NOTIFICATION_LIST_STYLES, selected);
+    if (!nextStyle) return;
+
+    event.preventDefault();
+    setStyle(nextStyle);
+    focusOption(optionsRef.current, nextStyle);
+  }
+
+  return (
+    <>
+      <header className="flex shrink-0 items-center gap-2 border-b border-[var(--color-border)] px-3 py-2.5">
+        <Button
+          intent="toggle"
+          size="iconXs"
+          title={t("picker.back")}
+          aria-label={t("picker.back")}
+          onClick={onBack}
+          leadingIcon={<BackIcon size={14} />}
+          iconOnly
+        />
+        <h2 className="text-sm font-semibold tracking-tight text-[var(--color-text)]">
+          {t("picker.title")}
+        </h2>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <p className="text-xs leading-relaxed text-[var(--color-text-muted)]">{t("picker.hint")}</p>
+        <div
+          ref={optionsRef}
+          role="radiogroup"
+          aria-label={t("picker.title")}
+          onKeyDown={onKeyDown}
+          className="mt-3 flex flex-col gap-2"
+        >
+          {NOTIFICATION_LIST_STYLES.map((style) => (
+            <StyleOption
+              key={style}
+              style={style}
+              name={t(`style.${style}.name`)}
+              hint={t(`style.${style}.hint`)}
+              selected={style === selected}
+              onSelect={() => setStyle(style)}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+interface StyleOptionProps {
+  style: NotificationListStyle;
+  name: string;
+  hint: string;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+function StyleOption({ style, name, hint, selected, onSelect }: StyleOptionProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      data-style={style}
+      aria-checked={selected}
+      tabIndex={selected ? 0 : -1}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full cursor-pointer flex-col gap-2 rounded-[var(--radius-md)] border p-2.5 text-start transition-colors duration-[var(--motion-fast)] ease-[var(--motion-easing)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]",
+        selected
+          ? "border-[var(--color-primary)] bg-[var(--color-primary-soft)]"
+          : "border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-2)]",
+      )}
+    >
+      <NotificationStylePreview style={style} />
+      <span className="flex items-start gap-2">
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium text-[var(--color-text)]">{name}</span>
+          <span className="mt-0.5 block text-xs leading-snug text-[var(--color-text-muted)]">
+            {hint}
+          </span>
+        </span>
+        {selected ? (
+          <Check
+            size={14}
+            aria-hidden="true"
+            className="mt-0.5 shrink-0 text-[var(--color-primary)]"
+          />
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+function focusOption(options: HTMLDivElement | null, style: NotificationListStyle) {
+  options?.querySelector<HTMLButtonElement>(`[data-style="${style}"]`)?.focus();
+}

--- a/src/features/notification/ui/notification-style-picker.tsx
+++ b/src/features/notification/ui/notification-style-picker.tsx
@@ -1,11 +1,11 @@
 import { ArrowLeft, ArrowRight, Check } from "lucide-react";
-import { type KeyboardEvent, useEffect, useRef } from "react";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type NotificationListStyle, usePreferencesStore } from "@/shared/config";
 import { getDirection } from "@/shared/i18n";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { nextRovingChoice } from "../lib/roving-choice";
+import { focusRovingChoice, nextRovingChoice } from "../lib/roving-choice";
 import { NOTIFICATION_LIST_STYLES } from "../model/notification-list-style";
 import { NotificationStylePreview } from "./notification-style-preview";
 
@@ -20,25 +20,29 @@ export function NotificationStylePicker({ onBack }: NotificationStylePickerProps
   const selected = usePreferencesStore((preferences) => preferences.notificationListStyle);
   const setStyle = usePreferencesStore((preferences) => preferences.setNotificationListStyle);
   const optionsRef = useRef<HTMLDivElement>(null);
+  const [focused, setFocused] = useState(selected);
 
   const direction = getDirection(locale);
   const BackIcon = direction === "rtl" ? ArrowRight : ArrowLeft;
 
-  // The picker is remounted by the very choice it applies — the shape around it changes — so
-  // it takes focus back to the chosen option, and arrow keys keep walking where they left off.
+  // Choosing a style rebuilds the shape around the picker, taking the focused option with it,
+  // so the remounted picker puts focus back where the reader left it.
   useEffect(() => {
-    focusOption(optionsRef.current, selected);
+    focusRovingChoice(optionsRef.current, selected);
   }, [selected]);
 
-  // Arrow keys walk the group, as they do in any radio group; the buttons themselves carry a
-  // roving tab stop so Tab leaves the group rather than stepping through it.
+  /**
+   * Arrows move the focus, and Enter or Space takes the option. Selection deliberately does
+   * not follow focus here as it would in a plain radio group: every choice rebuilds the whole
+   * center and is written to disk, which is too much to spend on passing over an option.
+   */
   function onKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    const nextStyle = nextRovingChoice(event.key, direction, NOTIFICATION_LIST_STYLES, selected);
-    if (!nextStyle) return;
+    const next = nextRovingChoice(event.key, direction, NOTIFICATION_LIST_STYLES, focused);
+    if (!next) return;
 
     event.preventDefault();
-    setStyle(nextStyle);
-    focusOption(optionsRef.current, nextStyle);
+    setFocused(next);
+    focusRovingChoice(optionsRef.current, next);
   }
 
   return (
@@ -74,7 +78,11 @@ export function NotificationStylePicker({ onBack }: NotificationStylePickerProps
               name={t(`style.${style}.name`)}
               hint={t(`style.${style}.hint`)}
               selected={style === selected}
-              onSelect={() => setStyle(style)}
+              focused={style === focused}
+              onSelect={() => {
+                setFocused(style);
+                setStyle(style);
+              }}
             />
           ))}
         </div>
@@ -88,17 +96,19 @@ interface StyleOptionProps {
   name: string;
   hint: string;
   selected: boolean;
+  /** Holds the group's single tab stop, which the arrow keys move without choosing. */
+  focused: boolean;
   onSelect: () => void;
 }
 
-function StyleOption({ style, name, hint, selected, onSelect }: StyleOptionProps) {
+function StyleOption({ style, name, hint, selected, focused, onSelect }: StyleOptionProps) {
   return (
     <button
       type="button"
       role="radio"
-      data-style={style}
+      data-choice={style}
       aria-checked={selected}
-      tabIndex={selected ? 0 : -1}
+      tabIndex={focused ? 0 : -1}
       onClick={onSelect}
       className={cn(
         "flex w-full cursor-pointer flex-col gap-2 rounded-[var(--radius-md)] border p-2.5 text-start transition-colors duration-[var(--motion-fast)] ease-[var(--motion-easing)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-primary)]",
@@ -125,8 +135,4 @@ function StyleOption({ style, name, hint, selected, onSelect }: StyleOptionProps
       </span>
     </button>
   );
-}
-
-function focusOption(options: HTMLDivElement | null, style: NotificationListStyle) {
-  options?.querySelector<HTMLButtonElement>(`[data-style="${style}"]`)?.focus();
 }

--- a/src/features/notification/ui/notification-style-preview.tsx
+++ b/src/features/notification/ui/notification-style-preview.tsx
@@ -6,7 +6,7 @@ interface NotificationStylePreviewProps {
 }
 
 const stageClassName =
-  "relative h-[68px] w-full overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-2)]";
+  "relative h-16 w-full overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-2)]";
 
 const surfaceClassName =
   "rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)]";
@@ -20,7 +20,7 @@ export function NotificationStylePreview({ style }: NotificationStylePreviewProp
   if (style === "sheet") {
     return (
       <div aria-hidden="true" className={stageClassName}>
-        <div className="absolute inset-0 bg-[color-mix(in_srgb,var(--color-text)_18%,transparent)]" />
+        <div className="absolute inset-0 bg-[var(--color-overlay)]" />
         <div
           className={cn(
             "absolute inset-y-1.5 end-1.5 w-1/2 p-1.5",
@@ -29,6 +29,7 @@ export function NotificationStylePreview({ style }: NotificationStylePreviewProp
           )}
         >
           <PreviewHeading />
+          <PreviewRow lines={2} />
           <PreviewRow lines={2} />
           <PreviewRow lines={2} muted />
         </div>
@@ -40,10 +41,10 @@ export function NotificationStylePreview({ style }: NotificationStylePreviewProp
     return (
       <div aria-hidden="true" className={stageClassName}>
         <div className={cn("absolute inset-x-1.5 top-1.5 bottom-1.5 p-1.5", surfaceClassName)}>
-          <div className="flex gap-1">
-            <span className="h-2 w-6 rounded-full bg-[var(--color-primary-fill)]" />
-            <span className="h-2 w-6 rounded-full bg-[var(--color-surface-2)]" />
-          </div>
+          <span className="flex w-fit gap-0.5 rounded-[var(--radius-sm)] bg-[var(--color-surface-2)] p-0.5">
+            <span className="h-2 w-6 rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)]" />
+            <span className="h-2 w-6" />
+          </span>
           <div className="mt-1.5 flex flex-col gap-1">
             <PreviewRow lines={1} />
             <PreviewRow lines={1} />
@@ -66,6 +67,7 @@ export function NotificationStylePreview({ style }: NotificationStylePreviewProp
       >
         <PreviewHeading />
         <PreviewRow lines={2} />
+        <PreviewRow lines={2} />
         <PreviewRow lines={2} muted />
       </div>
     </div>
@@ -86,7 +88,7 @@ function PreviewRow({ lines, muted = false }: PreviewRowProps) {
     <span className="flex items-start gap-1">
       <span
         className={cn(
-          "mt-px size-2 shrink-0 rounded-[2px]",
+          "mt-px size-2 shrink-0 rounded-[var(--radius-sm)]",
           muted ? "bg-[var(--color-surface-2)]" : "bg-[var(--color-primary-soft)]",
         )}
       />

--- a/src/features/notification/ui/notification-style-preview.tsx
+++ b/src/features/notification/ui/notification-style-preview.tsx
@@ -1,0 +1,106 @@
+import type { NotificationListStyle } from "@/shared/config";
+import { cn } from "@/shared/lib/cn";
+
+interface NotificationStylePreviewProps {
+  style: NotificationListStyle;
+}
+
+const stageClassName =
+  "relative h-[68px] w-full overflow-hidden rounded-[var(--radius-md)] border border-[var(--color-border)] bg-[var(--color-surface-2)]";
+
+const surfaceClassName =
+  "rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface)]";
+
+/**
+ * A miniature of the shape, drawn from the same tokens the shape itself uses, so what the
+ * reader compares is the real thing in the current theme and direction rather than a picture
+ * of it in someone else's.
+ */
+export function NotificationStylePreview({ style }: NotificationStylePreviewProps) {
+  if (style === "sheet") {
+    return (
+      <div aria-hidden="true" className={stageClassName}>
+        <div className="absolute inset-0 bg-[color-mix(in_srgb,var(--color-text)_18%,transparent)]" />
+        <div
+          className={cn(
+            "absolute inset-y-1.5 end-1.5 w-1/2 p-1.5",
+            surfaceClassName,
+            "flex flex-col gap-1.5",
+          )}
+        >
+          <PreviewHeading />
+          <PreviewRow lines={2} />
+          <PreviewRow lines={2} muted />
+        </div>
+      </div>
+    );
+  }
+
+  if (style === "flat") {
+    return (
+      <div aria-hidden="true" className={stageClassName}>
+        <div className={cn("absolute inset-x-1.5 top-1.5 bottom-1.5 p-1.5", surfaceClassName)}>
+          <div className="flex gap-1">
+            <span className="h-2 w-6 rounded-full bg-[var(--color-primary-fill)]" />
+            <span className="h-2 w-6 rounded-full bg-[var(--color-surface-2)]" />
+          </div>
+          <div className="mt-1.5 flex flex-col gap-1">
+            <PreviewRow lines={1} />
+            <PreviewRow lines={1} />
+            <PreviewRow lines={1} muted />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div aria-hidden="true" className={stageClassName}>
+      <span className="absolute top-1.5 end-1.5 size-1.5 rounded-full bg-[var(--color-primary)]" />
+      <div
+        className={cn(
+          "absolute top-4 end-1.5 w-2/3 p-1.5",
+          surfaceClassName,
+          "flex flex-col gap-1.5 shadow-[var(--shadow-sm)]",
+        )}
+      >
+        <PreviewHeading />
+        <PreviewRow lines={2} />
+        <PreviewRow lines={2} muted />
+      </div>
+    </div>
+  );
+}
+
+function PreviewHeading() {
+  return <span className="h-1.5 w-8 rounded-full bg-[var(--color-text-faint)]" />;
+}
+
+interface PreviewRowProps {
+  lines: 1 | 2;
+  muted?: boolean;
+}
+
+function PreviewRow({ lines, muted = false }: PreviewRowProps) {
+  return (
+    <span className="flex items-start gap-1">
+      <span
+        className={cn(
+          "mt-px size-2 shrink-0 rounded-[2px]",
+          muted ? "bg-[var(--color-surface-2)]" : "bg-[var(--color-primary-soft)]",
+        )}
+      />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span
+          className={cn(
+            "h-1 w-full rounded-full",
+            muted ? "bg-[var(--color-surface-2)]" : "bg-[var(--color-border)]",
+          )}
+        />
+        {lines === 2 ? (
+          <span className="h-1 w-2/3 rounded-full bg-[var(--color-surface-2)]" />
+        ) : null}
+      </span>
+    </span>
+  );
+}

--- a/src/features/notification/ui/notification-tier-badge.test.tsx
+++ b/src/features/notification/ui/notification-tier-badge.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import i18next from "i18next";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { AuthSession, SessionUser } from "@/shared/auth";
+import { useAuthStore } from "@/shared/auth";
+import { NotificationBell } from "./notification-bell";
+
+const apiGetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/shared/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api")>()),
+  apiClient: { get: apiGetMock, post: vi.fn() },
+}));
+
+const testI18n = i18next.createInstance();
+
+const platformAdmin: SessionUser = {
+  publicId: "admin-1",
+  employeeCode: "ADM-001",
+  firstName: "Amina",
+  lastName: "Saleh",
+  email: "amina@edara.test",
+  status: "ACTIVE",
+  companyCode: "EDARA",
+  mustChangePassword: false,
+  permissions: [],
+  isOwner: false,
+  isPlatformAdmin: true,
+};
+
+const session: AuthSession = {
+  accessToken: "access-token",
+  refreshToken: "refresh-token",
+  sessionId: "session-1",
+  expiresIn: 900,
+  user: platformAdmin,
+};
+
+function stubCount(unreadCount: number) {
+  apiGetMock.mockImplementation((path: string) => {
+    if (path.endsWith("unread-count")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ unreadCount }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+
+    return { json: async () => ({ items: [], nextCursor: null, hasMore: false }) };
+  });
+}
+
+function renderBell() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <QueryClientProvider client={queryClient}>
+        <NotificationBell />
+      </QueryClientProvider>
+    </I18nextProvider>,
+  );
+}
+
+beforeAll(async () => {
+  await testI18n.init({
+    lng: "en",
+    fallbackLng: "en",
+    ns: ["notification"],
+    defaultNS: "notification",
+    keySeparator: false,
+    interpolation: { escapeValue: false },
+    resources: { en: { notification: { "panel.title": "Notifications" } } },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useAuthStore.setState({ session: null, status: "anonymous" });
+});
+
+describe("the badge a Platform Admin sees", () => {
+  it("counts the platform mount, not the company one", async () => {
+    useAuthStore.setState({ session, status: "authenticated" });
+    stubCount(1);
+    renderBell();
+
+    expect(await screen.findByText("1")).toBeInTheDocument();
+    expect(apiGetMock).toHaveBeenCalledWith("platform/notifications/unread-count", {
+      headers: undefined,
+    });
+  });
+});

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -1,1 +1,5 @@
-export { type ThemeMode, usePreferencesStore } from "./preferences-store";
+export {
+  type NotificationListStyle,
+  type ThemeMode,
+  usePreferencesStore,
+} from "./preferences-store";

--- a/src/shared/config/preferences-store.test.ts
+++ b/src/shared/config/preferences-store.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { usePreferencesStore } from "./preferences-store";
+
+const STORAGE_KEY = "hrms-prefs";
+
+afterEach(() => {
+  usePreferencesStore.setState({ notificationListStyle: "panel" });
+  localStorage.removeItem(STORAGE_KEY);
+});
+
+describe("notification list style preference", () => {
+  it("opens the notification center as the anchored panel until the reader says otherwise", () => {
+    expect(usePreferencesStore.getState().notificationListStyle).toBe("panel");
+  });
+
+  it("keeps the chosen style across a reload", async () => {
+    usePreferencesStore.getState().setNotificationListStyle("flat");
+
+    // `persist` writes after the state settles, and rehydration reads what it wrote.
+    await usePreferencesStore.persist.rehydrate();
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}").state).toMatchObject({
+      notificationListStyle: "flat",
+    });
+    expect(usePreferencesStore.getState().notificationListStyle).toBe("flat");
+  });
+});

--- a/src/shared/config/preferences-store.ts
+++ b/src/shared/config/preferences-store.ts
@@ -4,14 +4,19 @@ import type { SupportedLocale } from "@/shared/i18n";
 
 export type ThemeMode = "light" | "dark";
 
+/** Which shape the notification center opens in: anchored panel, end-side sheet, compact list. */
+export type NotificationListStyle = "panel" | "sheet" | "flat";
+
 interface PreferencesState {
   locale: SupportedLocale;
   theme: ThemeMode;
   sidebarCollapsed: boolean;
+  notificationListStyle: NotificationListStyle;
   setLocale: (locale: SupportedLocale) => void;
   setTheme: (theme: ThemeMode) => void;
   toggleTheme: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  setNotificationListStyle: (style: NotificationListStyle) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -20,10 +25,12 @@ export const usePreferencesStore = create<PreferencesState>()(
       locale: "en",
       theme: "light",
       sidebarCollapsed: false,
+      notificationListStyle: "panel",
       setLocale: (locale) => set({ locale }),
       setTheme: (theme) => set({ theme }),
       toggleTheme: () => set((state) => ({ theme: state.theme === "light" ? "dark" : "light" })),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
+      setNotificationListStyle: (notificationListStyle) => set({ notificationListStyle }),
     }),
     {
       name: "hrms-prefs",

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -4,5 +4,5 @@ export {
   type SupportedLocale,
   supportedLocales,
 } from "./config";
-export { applyDocumentDirection, getDirection } from "./direction";
+export { applyDocumentDirection, getDirection, type TextDirection } from "./direction";
 export { LocaleRuntime } from "./locale-runtime";

--- a/src/shared/lib/use-clipped-text.ts
+++ b/src/shared/lib/use-clipped-text.ts
@@ -1,0 +1,39 @@
+import { type RefObject, useCallback, useEffect, useState } from "react";
+
+/**
+ * Sub-pixel rounding makes `scrollWidth` overshoot `clientWidth` by a fraction on text that
+ * fits perfectly well, so a bare comparison would tooltip half the table.
+ */
+const OVERFLOW_TOLERANCE_PX = 1;
+
+function isTextClipped(element: HTMLElement): boolean {
+  return element.scrollWidth - element.clientWidth > OVERFLOW_TOLERANCE_PX;
+}
+
+/**
+ * Whether the line inside `ref` was cut to fit its container — the one thing worth offering
+ * a tooltip for. The same text clips or fits depending on where it lands, and containers
+ * resize with the window, the sidebar, and a density control, so this re-measures on both.
+ */
+export function useClippedText(ref: RefObject<HTMLElement | null>, text: string): boolean {
+  const [clipped, setClipped] = useState(false);
+
+  const measure = useCallback(() => {
+    const element = ref.current;
+    if (element) setClipped(isTextClipped(element));
+  }, [ref]);
+
+  useEffect(() => {
+    measure();
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [measure, ref]);
+
+  useEffect(measure, [measure, text]);
+
+  return clipped;
+}

--- a/src/shared/ui/tooltip.tsx
+++ b/src/shared/ui/tooltip.tsx
@@ -2,6 +2,9 @@ import { type ReactNode, useCallback, useEffect, useId, useRef, useState } from 
 import { createPortal } from "react-dom";
 import { cn } from "@/shared/lib/cn";
 
+/** `auto` sits above the trigger and drops below only when the top of the window is in the way. */
+export type TooltipPlacement = "auto" | "below";
+
 interface TooltipProps {
   /** The words the tooltip shows. Nothing renders when this is empty. */
   content: ReactNode;
@@ -10,6 +13,7 @@ interface TooltipProps {
   disabled?: boolean;
   /** Adds a tab stop so a keyboard reaches this tooltip. Leave off inside a focusable parent. */
   focusable?: boolean;
+  placement?: TooltipPlacement;
   className?: string;
 }
 
@@ -38,6 +42,7 @@ export function Tooltip({
   children,
   disabled = false,
   focusable = false,
+  placement = "auto",
   className,
 }: TooltipProps) {
   const tooltipId = useId();
@@ -55,9 +60,13 @@ export function Tooltip({
     const tooltip = tooltipRef.current?.getBoundingClientRect();
     const width = tooltip?.width ?? 0;
     const height = tooltip?.height ?? 0;
-    // Above the trigger unless the trigger sits too near the top of the window.
+    // Above the trigger unless the trigger sits too near the top of the window — or unless
+    // the caller asked for below, which still flips up rather than run off the bottom.
     const above = trigger.top - height - OFFSET;
-    const top = above < VIEWPORT_MARGIN ? trigger.bottom + OFFSET : above;
+    const below = trigger.bottom + OFFSET;
+    const fitsBelow = below + height <= window.innerHeight - VIEWPORT_MARGIN;
+    const goesBelow = placement === "below" ? fitsBelow : above < VIEWPORT_MARGIN;
+    const top = goesBelow ? below : above;
     const centered = trigger.left + trigger.width / 2 - width / 2;
     const maxLeft = window.innerWidth - width - VIEWPORT_MARGIN;
 
@@ -65,7 +74,7 @@ export function Tooltip({
       top,
       left: Math.min(Math.max(centered, VIEWPORT_MARGIN), Math.max(maxLeft, VIEWPORT_MARGIN)),
     });
-  }, []);
+  }, [placement]);
 
   const hide = useCallback(() => {
     window.clearTimeout(openTimeout.current);

--- a/src/shared/ui/truncated-text.tsx
+++ b/src/shared/ui/truncated-text.tsx
@@ -1,24 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { cn } from "@/shared/lib/cn";
-import { Tooltip } from "@/shared/ui/tooltip";
+import { useClippedText } from "@/shared/lib/use-clipped-text";
+import { Tooltip, type TooltipPlacement } from "@/shared/ui/tooltip";
 
 interface TruncatedTextProps {
   text: string;
   /** Adds a tab stop when the text is clipped. Leave off inside an already-focusable parent. */
   focusable?: boolean;
+  placement?: TooltipPlacement;
   className?: string;
-}
-
-/**
- * A single line that may not fit, and says so only when it doesn't.
- *
- * Sub-pixel rounding makes `scrollWidth` overshoot `clientWidth` by a fraction on text that
- * fits perfectly well, so a bare comparison would tooltip half the table.
- */
-const OVERFLOW_TOLERANCE_PX = 1;
-
-function isTextClipped(element: HTMLElement): boolean {
-  return element.scrollWidth - element.clientWidth > OVERFLOW_TOLERANCE_PX;
 }
 
 /**
@@ -26,31 +16,22 @@ function isTextClipped(element: HTMLElement): boolean {
  * truncation actually happened. A tooltip that repeats text already fully on screen is noise,
  * and noise is what stops people reading tooltips at all.
  */
-export function TruncatedText({ text, focusable = true, className }: TruncatedTextProps) {
+export function TruncatedText({
+  text,
+  focusable = true,
+  placement,
+  className,
+}: TruncatedTextProps) {
   const textRef = useRef<HTMLSpanElement>(null);
-  const [clipped, setClipped] = useState(false);
-
-  const measure = useCallback(() => {
-    const element = textRef.current;
-    if (element) setClipped(isTextClipped(element));
-  }, []);
-
-  // The same text clips or fits depending on the column it lands in, and columns resize with
-  // the window, the sidebar, and the density control.
-  useEffect(() => {
-    measure();
-    const element = textRef.current;
-    if (!element || typeof ResizeObserver === "undefined") return;
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [measure]);
-
-  useEffect(measure, [measure, text]);
+  const clipped = useClippedText(textRef, text);
 
   return (
-    <Tooltip content={text} disabled={!clipped} focusable={focusable && clipped}>
+    <Tooltip
+      content={text}
+      disabled={!clipped}
+      focusable={focusable && clipped}
+      placement={placement}
+    >
       <span ref={textRef} className={cn("block truncate", className)}>
         {text}
       </span>


### PR DESCRIPTION
Part of #53 (EPIC: In-App Notification System — frontend).

Three things, all in the notification centre.

## 1. List style is now the reader's choice (ADR 0003)
`panel` (the existing dropdown), `sheet` (end-side, over a scrim, roomier rows), and `flat` (compact, no day headings, All/Unread filter). The choice lives in a style-picker view swapped into whichever shape is open — reachable from a gear in every header, no new routes — and persists client-side in the same store as theme and locale. Each option previews as a live miniature built only from design tokens, so light/dark and LTR/RTL are correct for free.

The bell owns open/close, the view, **and** the single `useNotificationCenter`, so all three shapes render from one feed query and one set of lifecycle mutations. The badge contract is untouched: a count pill under every shape, capped at 99+, from the unread-count endpoint alone.

## 2. A clipped notification reveals its full copy on hover
One tooltip carrying title and body, anchored below the row, shown only when the row actually clipped something.

## 3. A new Lead now toasts
`platform.lead-created` moves to high importance in the frontend catalog mirror, matching HRMS_Back_End#(lead-created-high-importance). Normal-importance types still wait in the bell.

## Acceptance criteria
- [x] All three shapes work against the real feed: buckets/chips, seen/read lifecycle, mark-all, Escape/outside-click, sheet scrim + scroll lock, focus management per shape
- [x] Per-row mark-read works by mouse and keyboard, is aria-labelled, and gives non-navigable rows an individual read path
- [x] Flat "Unread" filters cached rows to state != read; badge unaffected
- [x] Picker reachable from every shape, back returns, instant apply, choice survives reload
- [x] Previews render from tokens in light+dark and LTR+RTL; no images
- [x] Slice public API unchanged (`NotificationBell`, `NotificationToaster`); Steiger passes
- [x] All new copy exists in en + ar

## Gates
`bun run typecheck`, `bun run lint` (biome + steiger), `bun run test` — **389 tests in 69 files**, `bun run build`. `react-doctor` flags nothing in the notification slice.

## Review notes
Both axes of `/code-review` ran and their findings were applied, including two real defects: the seen-on-open write could fire twice when the shape swapped while open (each shape owned its own center — hoisted to the bell), and arrow keys were committing *and persisting* the preference just for passing over an option (they now move focus; Enter/Space or click chooses).

Also fixed a latent test fragility: the recency-bucket suites read the wall clock and failed either side of midnight; they now pin a fixed midday `now`.
